### PR TITLE
Fixing Typo Single Word

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@ $stmt-&gt;execute();</pre>
             <h3>Full-Stack Frameworks</h3>
             <ul>
                 <li><a href="http://www.symfony-project.org/">Symfony</a></li>
-                <li><a href="http://codeigniter.com/">CodeIgnitor</a></li>
+                <li><a href="http://codeigniter.com/">CodeIgniter</a></li>
                 <li><a href="http://cakephp.org/">Cake PHP</a></li>
                 <li><a href="http://framework.zend.com/">Zend</a></li>
                 <li><a href="http://www.yiiframework.com/">Yii</a></li>


### PR DESCRIPTION
Fixing small minor on "Codeignitor" typo
