### PR TITLE
Link to Symfony2

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@ $stmt-&gt;execute();</pre>
 
             <h3>Full-Stack Frameworks</h3>
             <ul>
-                <li><a href="http://www.symfony-project.org/">Symfony</a></li>
+                <li><a href="http://symfony.com/">Symfony</a></li>
                 <li><a href="http://www.yiiframework.com/">Yii</a></li>
                 <li><a href="http://laravel.com/">Laravel</a></li>
                 <li><a href="http://kohanaframework.org/">Kohana</a></li>


### PR DESCRIPTION
The symfony link refers to the site of the v1 version of the framework. It's probably better to link to the new v2 version.
