### PR TITLE
Use input filtering in the PDO section

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@ $pdo-&gt;query(&quot;SELECT * FROM users WHERE id = &quot; . $_GET['id']); // <-
             <pre>&lt;?php
 $pdo = new PDO('sqlite:users.db');
 $stmt = $pdo-&gt;prepare('SELECT * FROM users WHERE id = :id');
-$stmt-&gt;bindParam(':id', (int)$_GET['id'], PDO::PARAM_INT);
+$stmt-&gt;bindParam(':id', filter_input(FILTER_GET, 'id', FILTER_SANITIZE_NUMBER_INT), PDO::PARAM_INT);
 $stmt-&gt;execute();</pre>
             <p>
                 This is correct code. It uses a bound parameter on a PDO statement. This escapes the foreign


### PR DESCRIPTION
Since the section right above suggests (rightly) to use input filtering, makes sense that we should use it at the critical junction of inserting into the DB, even if PDO does properly sanitize it.  It's both safer and helps the tutorial build on previous examples in a cohesive way.
