### PR TITLE
Added Windows Azure as a PHP PaaS Provider

### DIFF
--- a/_includes/resources.md
+++ b/_includes/resources.md
@@ -22,5 +22,6 @@
 * [dotCloud](http://docs.dotcloud.com/services/php/)
 * [AWS Elastic Beanstalk](http://aws.amazon.com/elasticbeanstalk/)
 * [cloudControl](https://www.cloudcontrol.com/)
+* [Windows Azure](http://www.windowsazure.com/)
 
 [Back to Top](#top){.top}


### PR DESCRIPTION
Windows Azure is a great way to host PHP, just thought i'd add it to the list.
