### PR TITLE
adjusted code samples to follow PSR where applicable

### DIFF
--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -19,8 +19,7 @@ PHP has had annonymous functions since PHP 5.3:
 
 {% highlight php %}
 <?php
-$greet = function($name)
-{
+$greet = function ($name) {
     print("Hello {$name}");
 };
 

--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -20,7 +20,7 @@ Let's write a simple "Hello, $name" CLI program. To try it out, create a file na
 
 {% highlight php %}
 <?php
-if($argc != 2) {
+if ($argc != 2) {
     die("Usage: php hello.php [name].\n");
 }
 $name = $argv[1];

--- a/_posts/05-02-01-Exceptions.md
+++ b/_posts/05-02-01-Exceptions.md
@@ -26,16 +26,11 @@ $email->subject('My Subject');
 $email->body('How the heck are you?');
 $email->to('guy@example.com', 'Some Guy');
 
-try
-{
+try {
     $email->send();
-}
-catch(Fuel\Email\ValidationFailedException $e)
-{
+} catch(Fuel\Email\ValidationFailedException $e) {
     // The validation failed
-}
-catch(Fuel\Email\SendingFailedException $e)
-{
+} catch(Fuel\Email\SendingFailedException $e) {
     // The driver could not send the email
 }
 {% endhighlight %}
@@ -46,7 +41,10 @@ An Exception by default has no meaning and the most common to give it meaning is
 
 {% highlight php %}
 <?php
-class ValidationException extends Exception {}
+namespace YourCompany\SomeComponent;
+class ValidationException extends \Exception
+{
+}
 {% endhighlight %}
 
 This means you can add multiple catch blocks and handle different Exceptions differently. This can lead to 
@@ -54,7 +52,7 @@ the creation of a <em>lot</em> of custom Exceptions, some of which could have be
 provided in the [SPL extension][splext]. 
 
 If for example you use the `__call()` Magic Method and an invalid method is requested then instead of throwing a standard 
-Exception which is vague, or creating a custom Exception just for that, you could just `throw new BadFunctionCallException;`.
+Exception which is vague, or creating a custom Exception just for that, you could just `throw new \BadFunctionCallException;`.
 
 * [Read about Exceptions][exceptions]
 * [Read about SPL Exceptions][splexe]


### PR DESCRIPTION
If we believe PSR-\* is a part of best practices, we should use it in a document about best practices.
