### PR TITLE
Improvements to the "Virtual or Dedicated Servers" section

### DIFF
--- a/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
@@ -8,7 +8,7 @@ If you are comfortable with systems administration, or are interested in learnin
 
 ### nginx and PHP-FPM
 
-PHP, via PHP's built-in FastCGI Process Manager (FPM), pairs really nicely with [nginx](http://nginx.org), which is a lightweight, high-performance web server. It uses less memory than Apache and can better handle more concurrent requests. This is especially important on virtual servers that don't have much memory to spare. If you are working to put a new PHP app on its own server in production today, choose nginx and PHP-FPM.
+PHP, via PHP's built-in FastCGI Process Manager (FPM), pairs really nicely with [nginx](http://nginx.org), which is a lightweight, high-performance web server. It uses less memory than Apache and can better handle more concurrent requests. This is especially important on virtual servers that don't have much memory to spare.
 
 * [Read more on nginx](http://nginx.org)
 * [Read more on PHP-FPM](http://php.net/manual/en/install.fpm.php)
@@ -16,4 +16,4 @@ PHP, via PHP's built-in FastCGI Process Manager (FPM), pairs really nicely with 
 
 ### Apache and PHP
 
-PHP and Apache have a long history together. Apache is wildly configurable and allows sites to control their configurations dynamically, via `.htaccess` files, on a per-directory basis. This has made it a popular choice for shared servers and an easy setup for PHP frameworks and open source apps like WordPress. Unfortunately, Apache uses more resources than nginx and cannot handle as many visitors at the same time. If you are on your own virtual/dedicated server and do not need the configurability of Apache, choose nginx and PHP-FPM.
+PHP and Apache have a long history together. Apache is wildly configurable and allows sites to control their configurations dynamically, via `.htaccess` files, on a per-directory basis. This has made it a popular choice for shared servers and an easy setup for PHP frameworks and open source apps like WordPress. Unfortunately, Apache uses more resources than nginx and cannot handle as many visitors at the same time.

--- a/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
@@ -17,3 +17,11 @@ PHP, via PHP's built-in FastCGI Process Manager (FPM), pairs really nicely with 
 ### Apache and PHP
 
 PHP and Apache have a long history together. Apache is wildly configurable and allows sites to control their configurations dynamically, via `.htaccess` files, on a per-directory basis. This has made it a popular choice for shared servers and an easy setup for PHP frameworks and open source apps like WordPress. Unfortunately, Apache uses more resources than nginx and cannot handle as many visitors at the same time.
+
+Apache has several possible configurations for running PHP. The most common and easiest to setup is the [prefork MPM](http://httpd.apache.org/docs/2.0/mod/prefork.html) with mod_php5. While it isn't the most memory efficient, it is the simplest to get working and to use. This is probably the best choice if you don't want to dig too deeply into the server administration aspects.
+
+Alternatively, if you want to squeeze more performance out of Apache then you can take advantage of the same FPM system as nginx and run the [worker MPM](http://httpd.apache.org/docs/2.0/mod/worker.html) with mod_fastcgi or mod_fcgid. This configuration will be significantly more memory efficient and probably a bit faster but it is more work to set up and limits you to using only thread-safe code.
+
+* [Read more on Apache](http://httpd.apache.org/)
+* [Read more on Multi-Processing Modules](http://httpd.apache.org/docs/2.0/mpm.html)
+* [Read more on mod_fastcgi](http://www.fastcgi.com/mod_fastcgi/docs/mod_fastcgi.html)


### PR DESCRIPTION
- **Removed nginx preference.** I do agree that nginx is generally faster and less resource intensive, but Apache is the baseline. If newer PHP developers want to get started in a VPS or dedicated environment then Apache is probably where they are going to start. If for no other reason than because it does hold the title of _default_ web server. But also because many popular PHP apps and frameworks come setup for Apache, and most PHP tutorials where the server software matters are written for Apache.
- **Added more details about Apache.** I tried to keep it brief, just a high level overview with the most important things to know about Apache systems. I don't think detailed server admin information really fits in the context of this document, but I do believe that it should at least mention the important MPMs and mods available to run PHP.
