### PR TITLE
Fixes to apache - fastcgi runs fine with threaded worker or event mpm - ...

### DIFF
--- a/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
@@ -16,12 +16,13 @@ PHP, via PHP's built-in FastCGI Process Manager (FPM), pairs really nicely with 
 
 ### Apache and PHP
 
-PHP and Apache have a long history together. Apache is wildly configurable and allows sites to control their configurations dynamically, via `.htaccess` files, on a per-directory basis. This has made it a popular choice for shared servers and an easy setup for PHP frameworks and open source apps like WordPress. Unfortunately, Apache uses more resources than nginx and cannot handle as many visitors at the same time.
+PHP and Apache have a long history together. Apache is wildly configurable and has many available [modules](http://httpd.apache.org/docs/2.4/mod/) to extend functionality. It is a popular choice for shared servers and an easy setup for PHP frameworks and open source apps like WordPress. Unfortunately, Apache uses more resources than nginx by default and cannot handle as many visitors at the same time.
 
-Apache has several possible configurations for running PHP. The most common and easiest to setup is the [prefork MPM](http://httpd.apache.org/docs/2.0/mod/prefork.html) with mod_php5. While it isn't the most memory efficient, it is the simplest to get working and to use. This is probably the best choice if you don't want to dig too deeply into the server administration aspects.
+Apache has several possible configurations for running PHP. The most common and easiest to setup is the [prefork MPM](http://httpd.apache.org/docs/2.4/mod/prefork.html) with mod_php5. While it isn't the most memory efficient, it is the simplest to get working and to use. This is probably the best choice if you don't want to dig too deeply into the server administration aspects.  Note that if you use mod_php5 you MUST use the prefork MPM.
 
-Alternatively, if you want to squeeze more performance out of Apache then you can take advantage of the same FPM system as nginx and run the [worker MPM](http://httpd.apache.org/docs/2.0/mod/worker.html) with mod_fastcgi or mod_fcgid. This configuration will be significantly more memory efficient and probably a bit faster but it is more work to set up and limits you to using only thread-safe code.
+Alternatively, if you want to squeeze more performance and stability out of Apache then you can take advantage of the same FPM system as nginx and run the [worker MPM](http://httpd.apache.org/docs/2.4/mod/worker.html) or [event MPM](http://httpd.apache.org/docs/2.4/mod/event.html) with mod_fastcgi or mod_fcgid. This configuration will be significantly more memory efficient and much faster but it is more work to set up.
 
 * [Read more on Apache](http://httpd.apache.org/)
-* [Read more on Multi-Processing Modules](http://httpd.apache.org/docs/2.0/mpm.html)
+* [Read more on Multi-Processing Modules](http://httpd.apache.org/docs/2.4/mod/mpm_common.html)
 * [Read more on mod_fastcgi](http://www.fastcgi.com/mod_fastcgi/docs/mod_fastcgi.html)
+* [Read more on mod_fcgid](http://httpd.apache.org/mod_fcgid/)


### PR DESCRIPTION
...remember in fastcgi the PHP processes are separate and talk via socket.  Htacess talk is silly - that is actually module controlled anyway and other servers support that functionality including IIS :) - it's the module system of apache that sealed its popularity.

Note I also linked to the current apache version - not way way old docs - no reason we should push PHP 5.4 and not push the latest apache as well
