### PR TITLE
Added Codeception as BDD testing tool

### DIFF
--- a/_posts/08-03-01-Behavior-Driven-Development.md
+++ b/_posts/08-03-01-Behavior-Driven-Development.md
@@ -19,4 +19,4 @@ by the [RSpec project](http://rspec.info/) for Ruby.
 
 * [Behat](http://behat.org/) is inspired by Ruby's [Cucumber](http://cukes.info/) project 
 * [PHPSpec](http://www.phpspec.net/) the SpecBDD framework for PHP
-* [Selenium](http://seleniumhq.org/) is a browser automation tool, which can be [integrated with PHPUnit](http://www.phpunit.de/manual/3.1/en/selenium.html)
+* [Codeception](http://codeception.com) is designed write behavioral scenarios in PHP as from the eyes of actual tester.


### PR DESCRIPTION
Currently in Testing sections the idea of functional and acceptance testing is totally missed.
Ideally we should not mix this concerns with TDD and BDD as they are **development methodologies**, not the testing practices. 

TDD != Unit Testing
BDD != Acceptance Testing

Just to be clear.

I have removed the Selenium as it has nothing to do with BDD.
And I added [Codeception](http://codeception.com) which is more BDD, but still is full-stack testing framework for unit/functional/acceptance testing. 

Here is my articles on different testing approaches:
http://codeception.com/docs/01-Introduction
http://phpmaster.com/thoughts-of-a-pragmatic-tester/
