### PR TITLE
Updated Data Filtering section about "sanitisation"

### DIFF
--- a/_posts/07-04-01-Data-Filtering.md
+++ b/_posts/07-04-01-Data-Filtering.md
@@ -36,7 +36,11 @@ load hidden, non-public, or sensitive files.
 
 ### Escaping And Sanitization
 
-Sanitization removes illegal or unsafe characters from foreign input. Escaping does not alter the meaning of the input value but instead converts certain special characters into a safer escaped form, e.g. using HTML hexadecimal or named entities to prevent the injection of angle brackets that might allow new tags to be introduced into a HTML document while ensuring that angle brackets
+Sanitization removes illegal or unsafe characters from foreign input. Escaping 
+does not alter the meaning of the input value but instead converts certain 
+special characters into a safer escaped form, e.g. using HTML hexadecimal or 
+named entities to prevent the injection of angle brackets that might allow new 
+tags to be introduced into a HTML document while ensuring that angle brackets
 can still be included in the rendered text.
 
 For example, you should escape and/or sanitize foreign input before outputting it into 

--- a/_posts/07-04-01-Data-Filtering.md
+++ b/_posts/07-04-01-Data-Filtering.md
@@ -34,13 +34,14 @@ load hidden, non-public, or sensitive files.
 * [Learn about `filter_var`][4]
 * [Learn about `filter_input`][5]
 
-### Escaping and Sanitization
+### Escaping And Sanitization
 
-Sanitization removes illegal or unsafe characters from foreign input. Escaping does not alter the value of the input but instead converts certain special characters into a safer escaped form, e.g. using HTML hexadecimal or named entities to prevent the injection of angle brackets that might allow new tags to be introduced into a HTML document.
+Sanitization removes illegal or unsafe characters from foreign input. Escaping does not alter the meaning of the input value but instead converts certain special characters into a safer escaped form, e.g. using HTML hexadecimal or named entities to prevent the injection of angle brackets that might allow new tags to be introduced into a HTML document while ensuring that angle brackets
+can still be included in the rendered text.
 
-For example, you should escape foreign input before including the input in 
-HTML or inserting it into a raw SQL query. When you use bound parameters with
-[PDO](#databases), it will escape the input for you.
+For example, you should escape and/or sanitize foreign input before outputting it into 
+HTML or inserting it into a raw SQL query (for output to the database). When 
+you use bound parameters with [PDO](#databases), it will escape the input for you.
 
 The escaping required of foreign input will depend on the HTML context it is
 injected into. Escaping for HTML text differs from escaping for Javascript or
@@ -55,10 +56,11 @@ without the help of [HTML Purifier][html-purifier] which is considered the
 safest HTML sanitizer in PHP.
 
 Some programmers try to avoid the need for HTML sanitisation altogether by using
-restricted formatting languages like Markdown or BBCode. You should be
-aware, however, that these languages are intended to make it easier to
+formatting languages like Markdown or BBCode. You should be
+aware, however, that these languages are only intended to make it easier to
 write HTML by removing the complexity of HTML syntax as an editing
-barrier. The result of converting such languages to HTML will very likely still
+barrier (e.g. in blog comments or forum posts). The result of converting such 
+languages to HTML will very likely still
 require post-processing by [HTML Purifier][html-purifier] to remove potential
 Cross-Site Scripting (XSS) or UI Redress attempts by unfriendly users. When
 in doubt, use HTML sanitisation and you can't go wrong.

--- a/_posts/07-04-01-Data-Filtering.md
+++ b/_posts/07-04-01-Data-Filtering.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Data Filtering
+## Input Validation And Filtering
 
 Never ever (ever) trust foreign input introduced to your PHP code. Always sanitize and validate
 foreign input before using it in code. The `filter_var` and `filter_input` functions can sanitize text and validate text formats (e.g.
@@ -34,18 +34,34 @@ load hidden, non-public, or sensitive files.
 * [Learn about `filter_var`][4]
 * [Learn about `filter_input`][5]
 
-### Sanitization
+### Escaping and Sanitization
 
-Sanitization removes (or escapes) illegal or unsafe characters from foreign input.
+Sanitization removes illegal or unsafe characters from foreign input. Escaping does not alter the value of the input but instead converts certain special characters into a safer escaped form, e.g. using HTML hexadecimal or named entities to prevent the injection of angle brackets that might allow new tags to be introduced into a HTML document.
 
-For example, you should sanitize foreign input before including the input in HTML or inserting it
-into a raw SQL query. When you use bound parameters with [PDO](#databases), it will
-sanitize the input for you.
+For example, you should escape foreign input before including the input in 
+HTML or inserting it into a raw SQL query. When you use bound parameters with
+[PDO](#databases), it will escape the input for you.
 
-Sometimes it is required to allow some safe HTML tags in the input when including it in the HTML
-page. This is very hard to do and many avoid it by using other more restricted formatting like
-Markdown or BBCode, although whitelisting libraries like [HTML Purifier][html-purifier] exists for
-this reason.
+The escaping required of foreign input will depend on the HTML context it is
+injected into. Escaping for HTML text differs from escaping for Javascript or
+URL strings. You can find a reference implementation for context-specific
+escaping functions in this [Zend Escaper class](https://github.com/zendframework/zf2/blob/master/library/Zend/Escaper/Escaper.php).
+
+Sometimes it is required to allow some safe HTML tags (i.e. unescaped)
+in the input when 
+including it in the HTML page (as part of that page's markup). This is extremely difficult to do without introducing security vulnerabilities and 
+programmers should not attempt to sanitise HTML in this manner
+without the help of [HTML Purifier][html-purifier] which is considered the 
+safest HTML sanitizer in PHP.
+
+Some programmers try to avoid the need for HTML sanitisation altogether by using
+restricted formatting languages like Markdown or BBCode. You should be
+aware, however, that these languages are intended to make it easier to
+write HTML by removing the complexity of HTML syntax as an editing
+barrier. The result of converting such languages to HTML will very likely still
+require post-processing by [HTML Purifier][html-purifier] to remove potential
+Cross-Site Scripting (XSS) or UI Redress attempts by unfriendly users. When
+in doubt, use HTML sanitisation and you can't go wrong.
 
 [See Sanitization Filters][2]
 


### PR DESCRIPTION
- Highlighted difference between sanitisation (changes values) and escaping (preserves values)
- Emphasised reliance on HTMLPurifier for HTML sanitisation
- Added link to Zend\Escaper as a reference set of escaping functions by HTML context
- Noted Markdown/BBCode fallacy! Markdown accepts literal HTML (see spec) - MUST be sanitised after rendered to HTML. BBCode URLs often allow javascript: schema. Libraries usually do not sanitise output after rendering which does allow for XSS injections most of the time.
