### PR TITLE
Mac Setup fixes

### DIFF
--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -6,9 +6,11 @@ isChild: true
 
 OSX comes prepackaged with PHP but it is normally a little behind the latest stable. Lion comes with PHP 5.3.6 and Mountain Lion has 5.3.10.
 
-To update PHP on OSX you can get the PHP executable through a number of Mac [package managers][mac-package-managers] or [compile it yourself][mac-compile] (if compiling, be sure to have installed either Xcode or Apple's substitute ["Command Line Tools for Xcode" downloadable from Apple's Mac Developer Center][apple-developer]). 
+To update PHP on OSX you can get it installed through a number of Mac [package managers][mac-package-managers], with [php-osx by Liip][entropy-downloads] being recommended.
 
-For a complete LAMP package with GUI try [MAMP][mamp-downloads], otherwise consider the [Entropy 5.4][entropy-downloads] package.
+The other option is to [compile it yourself][mac-compile], in that case be sure to have installed either Xcode or Apple's substitute ["Command Line Tools for Xcode" downloadable from Apple's Mac Developer Center][apple-developer]. 
+
+For a complete "all-in-one" package including PHP, Apache web server and MySQL database, all this with a nice control GUI, try [MAMP][mamp-downloads].
 
 [mac-package-managers]: http://www.php.net/manual/en/install.macosx.packages.php
 [mac-compile]: http://www.php.net/manual/en/install.macosx.compile.php

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -4,17 +4,21 @@ isChild: true
 
 ## Mac Setup
 
-OSX comes prepackaged with PHP but it is normally a little behind the latest stable. Lion comes with PHP 5.3.6 and Mountain Lion has 5.3.10.
+OSX comes prepackaged with PHP but it is normally a little behind the latest stable. Lion comes with PHP 5.3.6 and
+Mountain Lion has 5.3.10.
 
-To update PHP on OSX you can get it installed through a number of Mac [package managers][mac-package-managers], with [php-osx by Liip][entropy-downloads] being recommended.
+To update PHP on OSX you can get it installed through a number of Mac [package managers][mac-package-managers], with
+[php-osx by Liip][php-osx-downloads] being recommended.
 
-The other option is to [compile it yourself][mac-compile], in that case be sure to have installed either Xcode or Apple's substitute ["Command Line Tools for Xcode" downloadable from Apple's Mac Developer Center][apple-developer]. 
+The other option is to [compile it yourself][mac-compile], in that case be sure to have installed either Xcode or
+Apple's substitute ["Command Line Tools for Xcode" downloadable from Apple's Mac Developer Center][apple-developer]. 
 
-For a complete "all-in-one" package including PHP, Apache web server and MySQL database, all this with a nice control GUI, try [MAMP][mamp-downloads].
+For a complete "all-in-one" package including PHP, Apache web server and MySQL database, all this with a nice control
+GUI, try [MAMP][mamp-downloads].
 
 [mac-package-managers]: http://www.php.net/manual/en/install.macosx.packages.php
 [mac-compile]: http://www.php.net/manual/en/install.macosx.compile.php
 [xcode-gcc-substitution]: https://github.com/kennethreitz/osx-gcc-installer
 [apple-developer]: https://developer.apple.com/downloads
 [mamp-downloads]: http://www.mamp.info/en/downloads/index.html
-[entropy-downloads]: http://php-osx.liip.ch/
+[php-osx-downloads]: http://php-osx.liip.ch/


### PR DESCRIPTION
- Redo MAMP description
- Move php-osx with the other package managers.

Follow on Issue #95.
