### PR TITLE
Tiny typo fixed

### DIFF
--- a/_posts/05-02-01-Exceptions.md
+++ b/_posts/05-02-01-Exceptions.md
@@ -16,7 +16,7 @@ looking for a mistake and check the docs to see what the error method is for thi
 obvious.
 
 Another problem is when classes automatically throw an error to the screen and exit the process. When you do this you 
-stop another developer from being able to dynamically handle that error. Exceptions should be throw to make a developer aware 
+stop another developer from being able to dynamically handle that error. Exceptions should be thrown to make a developer aware 
 of an error, then they can choose how to handle this. E.g:
 
 {% highlight php %}


### PR DESCRIPTION
Fixed a tiny typo I saw: `should be throw` -> `should be thrown`.
