### PR TITLE
Rework error reporting section

### DIFF
--- a/_posts/07-07-01-Error-Reporting.md
+++ b/_posts/07-07-01-Error-Reporting.md
@@ -7,26 +7,28 @@ isChild: true
 PHP can report errors while running your code, like the syntax error (also known as parse error) or the error of
 accessing previously undefined variable or calling the undefined function.
 
-Error reporting can be useful in finding problem spots in your application and configuration directive `display_errors`
-can enable displaying reported errors in the output (e.g. in the web page content). In the production environment, this
-can expose details about your application to the attacker, making it easier to exploit any security issues in it. In
-some cases where foreign input is included in the error context, having this directive enabled may enable Cross-Site
-Scripting attacks.
+While error reporting is useful in finding problem spots in your application, there is a security concern about
+configuration directive `display_errors` to display reported errors in the output (e.g. in the web page content). In the
+production environment, this can expose details about your application to the attacker, making it __easier to exploit
+any security issues in it__. In cases where foreign input is included in the error context, having this directive
+enabled may enable Cross-Site Scripting attacks.
 
-The recommended settings to set in your `php.ini` (or what else your PHP environment uses for placing PHP configuration)
-are:
+Knowing this, recommended settings on error reporting to set in your `php.ini` (or what else your PHP environment uses
+for placing PHP configuration) are:
 
 - `display_errors = Off`
 - For PHP 5.4 `error_reporting = E_ALL` or `error_reporting = E_STRICT | E_ALL` for earlier versions.
 - `log_errors = On`
 
-You should configure `error_log` directive to select logging to a file, a web server log or to the system logging
-facility.
+You must also configure the `error_log` directive to select logging to a file, a web server log or to the system logging
+facility. With these settings, errors will be logged but will not be shown in the output.
 
-With these settings, errors will be logged but will not be shown in the output.
+With no errors displayed in the output, you will need to constantly monitor the log for any errors reported in your
+code in the development. This does not have to be hard, a simple terminal window tailing the log file will be just fine.
+If that is not convinient for you or if you are developing only simple web or CLI applications, you __may set
+`display_errors = On` only for your local development environment__ to help you see and fix reported errors more easily.
 
-If you are developing simple web or CLI applications, you may set `display_errors = On` in the development to help you
-see errors more easily. The problem is that this can break your output making reported errors hard to read. Some
-developers may prefer to look at log for errors and disable `display_errors` in the development too.
+In some cases displaying errors can break your output making reported errors hard to read. This is why some developers
+may prefer to look at log for errors and disable `display_errors` in the development too.
 
 * Continue reading on [Error Reporting](/pages/Error-Reporting.html)

--- a/_posts/07-07-01-Error-Reporting.md
+++ b/_posts/07-07-01-Error-Reporting.md
@@ -4,30 +4,25 @@ isChild: true
 
 ## Error Reporting
 
-Error logging can be useful in finding the problem spots in your application, but it can also expose infromation about 
-the structure of your application to the outside world. To effectively protect your application from issues that could 
-be caused by the output of these messages, you need to configure your server differently in development versus 
-production (live).
+PHP can report errors while running your code, like the syntax error (also known as parse error) or the error of
+accessing previously undefined variable or calling the undefined function.
 
-### Development
+Error reporting can be useful in finding problem spots in your application and configuration directive `display_errors`
+can enable displaying reported errors in the output (e.g. in the web page content). In the production environment, this
+can expose details about your application to the attacker, making it easier to exploit any security issues in it.
 
-To show errors in your <strong>development</strong> environment, configure the following settings in your `php.ini`:
+The recommended settings to set in your `php.ini` (or what else your PHP environment uses for placing PHP configuration)
+are:
 
-- display_errors: On
-- error_reporting: E_ALL
-- log_errors: On
+- `display_errors = Off`
+- For PHP 5.4 `error_reporting = E_ALL` or `error_reporting = E_STRICT | E_ALL` for earlier versions.
+- `log_errors = On`
 
-### Production
+You should also configure `error_log` directive to select logging to a file, web server log or to the system logging
+facility. 
 
-To hide the errors on your <strong>production</strong> environment, configure your `php.ini` as:
+With these settings, errors will be logged but will not be shown in the output. Some would say that setting
+`display_errors = On` is good for the development. The problem is that it can break your output making reported errors
+hard to read.
 
-- display_errors: Off
-- error_reporting: E_ALL
-- log_errors: On
-
-With these settings in production, errors will still be logged to the error logs for the web server, but will not be 
-shown to the user. For more information on these settings, see the PHP manual:
-
-* [Error_reporting](http://www.php.net/manual/en/errorfunc.configuration.php#ini.error-reporting)
-* [Display_errors](http://www.php.net/manual/en/errorfunc.configuration.php#ini.display-errors)
-* [Log_errors](http://www.php.net/manual/en/errorfunc.configuration.php#ini.log-errors)
+* Continue reading on [Error Reporting](/pages/Error-Reporting.html)

--- a/_posts/07-07-01-Error-Reporting.md
+++ b/_posts/07-07-01-Error-Reporting.md
@@ -9,7 +9,9 @@ accessing previously undefined variable or calling the undefined function.
 
 Error reporting can be useful in finding problem spots in your application and configuration directive `display_errors`
 can enable displaying reported errors in the output (e.g. in the web page content). In the production environment, this
-can expose details about your application to the attacker, making it easier to exploit any security issues in it.
+can expose details about your application to the attacker, making it easier to exploit any security issues in it. In
+some cases where foreign input is included in the error context, having this directive enabled may enable Cross-Site
+Scripting attacks.
 
 The recommended settings to set in your `php.ini` (or what else your PHP environment uses for placing PHP configuration)
 are:
@@ -18,11 +20,13 @@ are:
 - For PHP 5.4 `error_reporting = E_ALL` or `error_reporting = E_STRICT | E_ALL` for earlier versions.
 - `log_errors = On`
 
-You should also configure `error_log` directive to select logging to a file, web server log or to the system logging
-facility. 
+You should configure `error_log` directive to select logging to a file, a web server log or to the system logging
+facility.
 
-With these settings, errors will be logged but will not be shown in the output. Some would say that setting
-`display_errors = On` is good for the development. The problem is that it can break your output making reported errors
-hard to read.
+With these settings, errors will be logged but will not be shown in the output.
+
+If you are developing simple web or CLI applications, you may set `display_errors = On` in the development to help you
+see errors more easily. The problem is that this can break your output making reported errors hard to read. Some
+developers may prefer to look at log for errors and disable `display_errors` in the development too.
 
 * Continue reading on [Error Reporting](/pages/Error-Reporting.html)

--- a/pages/Error-Reporting.md
+++ b/pages/Error-Reporting.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: Error Reporting in PHP
+---
+
+# Error Reporting in PHP
+
+PHP can report errors while running your code, like the syntax error (also known as parse error) or the error of
+accessing previously undefined variable or calling the undefined function. For example:
+
+> PHP Fatal error:  Call to undefined function foo() in test.php on line 13
+
+Reported errors are described with different levels, from a notice to the fatal error like above. A separate level
+exists to add a warning when using deprecated features in the code that may be removed from the language in the future.
+
+When testing your application, error reporting is useful in finding problem spots. You should not ignore any reported
+error no matter how small it may look.
+
+Reported error will include a type, a short summary and a file and line location of the error in the code. Parse errors
+may report on a line following the real error location as PHP do not know what code you want to write and will stop
+executing only after reading a non-recognizable construct.
+
+There are a few PHP configuration directives for error reporting that can be set in `php.ini` (or what else your PHP
+environment uses for placing PHP configuration).
+
+It is possible to enable and disable error reporting for specific levels by setting the `error_reporting` configuration
+directive, or dynamically using the `error_reporting()` function. Configuration directive `log_errors` can enable error
+logging and `error_log` tells if errors should be logged into a file, to the web server log or the system logging
+facility. Another directive `display_errors` configures if reported errors will be displayed in the output (e.g. in
+the web page content).
+
+It is possible to override default error reporting with a custom error handler using the `set_error_handler()` function.
+Many frameworks do have their own error handlers enabled by default. Some PHP extensions may change the default error
+reporting handler to provide more features.
+
+For PHP 5.3, set `error_reporting = E_ALL | E_STRICT`.
+
+In PHP 5.4 `E_STRICT` is included in `E_ALL`, so it is enough to set `error_reporting = E_ALL`.
+
+Displaying errors is not the best way to look for reported errors. In the production environment, displayed errors can
+expose details about your application to the attacker, making it easier to exploit any security issues in it. There is
+another problem with displaying errors. Imagine writing code to respond on AJAX requests with a structured output format
+like JSON, or working with binary formats while outputting dynamically generated images or PDF files. If reported errors
+are displayed at random places in the output it will break the output format, making it invalid and the error text may
+be hard to read. All this will make development and testing very frustrating.
+
+That is why you should set `display_errors = Off` and configure error logging so it easy for you to monitor all reported
+errors both in the development and production. A custom error handler can display fallback content or some error text
+without sensitive internal details to the user.
+
+There are browser extensions and third party error reporting handlers to log reported errors from a web application
+directly to the web browser console. This may be used in the development if one finds separate error logging too
+inconvenient to setup and monitor.
+
+Custom runtime errors may be triggered in the code using `trigger_error()` function, but using exceptions is usually a
+better choice.
+
+For more information on these settings, see the PHP manual:
+
+* [Read about error handling and logging][errorhandling]
+* [Read about configuration directives on error reporting][errorhandling_configuration]
+
+[errorhandling]: http://www.php.net/manual/en/book.errorfunc.php
+[errorhandling_configuration]: http://www.php.net/manual/errorfunc.configuration.php
+

--- a/pages/Error-Reporting.md
+++ b/pages/Error-Reporting.md
@@ -33,20 +33,25 @@ It is possible to override default error reporting with a custom error handler u
 Many frameworks do have their own error handlers enabled by default. Some PHP extensions may change the default error
 reporting handler to provide more features.
 
+Custom error handler can display fallback content or some error text without sensitive internal details to the user.
+
 For PHP 5.3, set `error_reporting = E_ALL | E_STRICT`.
 
 In PHP 5.4 `E_STRICT` is included in `E_ALL`, so it is enough to set `error_reporting = E_ALL`.
 
-Displaying errors is not the best way to look for reported errors. In the production environment, displayed errors can
-expose details about your application to the attacker, making it easier to exploit any security issues in it. There is
-another problem with displaying errors. Imagine writing code to respond on AJAX requests with a structured output format
-like JSON, or working with binary formats while outputting dynamically generated images or PDF files. If reported errors
-are displayed at random places in the output it will break the output format, making it invalid and the error text may
-be hard to read. All this will make development and testing very frustrating.
+Configuration directive `display_errors` __must be off__ in the production environment as it can expose details about
+your application to the attacker, making it __easier to exploit any security issues__ in it. In some cases where foreign
+input is included in the error context, having this directive enabled may enable Cross-Site Scripting attacks.
 
-That is why you should set `display_errors = Off` and configure error logging so it easy for you to monitor all reported
-errors both in the development and production. A custom error handler can display fallback content or some error text
-without sensitive internal details to the user.
+If you are developing simple web or CLI applications, setting this directive on in the development may help you see
+errors more easily. Your code will be better without any errors reported. For example, to prevent reported notices about
+undefined variables or array indices use `isset()` or `empty()` and initialize variables before accessing them.
+
+More experienced developers may prefer to configure error logging so it easy to monitor all reported errors in the log
+and __disable `display_errors` in the development too__. Imagine writing code to respond on AJAX requests with a
+structured output format like JSON, or working with binary formats while outputting dynamically generated images. If
+reported errors are displayed at random places in the output it will break the output format, making it invalid and the
+error text may be hard to read. All this will make development and testing very frustrating.
 
 There are browser extensions and third party error reporting handlers to log reported errors from a web application
 directly to the web browser console. This may be used in the development if one finds separate error logging too

--- a/pages/Error-Reporting.md
+++ b/pages/Error-Reporting.md
@@ -35,23 +35,25 @@ reporting handler to provide more features.
 
 Custom error handler can display fallback content or some error text without sensitive internal details to the user.
 
-For PHP 5.3, set `error_reporting = E_ALL | E_STRICT`.
+For PHP 5.3, it is recommended to set `error_reporting = E_ALL | E_STRICT`.
 
-In PHP 5.4 `E_STRICT` is included in `E_ALL`, so it is enough to set `error_reporting = E_ALL`.
+In PHP 5.4 `E_STRICT` is included in `E_ALL`, so setting `error_reporting = E_ALL` is enough.
 
-Configuration directive `display_errors` __must be off__ in the production environment as it can expose details about
-your application to the attacker, making it __easier to exploit any security issues__ in it. In some cases where foreign
+Configuration directive `display_errors` __must be Off__ in the production environment as it can expose details about
+your application to the attacker, making it __easier to exploit any security issues__ in it. In cases where foreign
 input is included in the error context, having this directive enabled may enable Cross-Site Scripting attacks.
 
-If you are developing simple web or CLI applications, setting this directive on in the development may help you see
-errors more easily. Your code will be better without any errors reported. For example, to prevent reported notices about
-undefined variables or array indices use `isset()` or `empty()` and initialize variables before accessing them.
+In the development, with `display_errors` disabled you will need to constantly monitor the log for any errors reported
+in your code. This does not have to be hard, a simple terminal window tailing the log file will be just fine. If that is
+not right for you or if you are developing only simple web or CLI applications, you __may set `display_errors = On` only
+for your local development environment__ to help you see and fix reported errors more easily.
 
-More experienced developers may prefer to configure error logging so it easy to monitor all reported errors in the log
-and __disable `display_errors` in the development too__. Imagine writing code to respond on AJAX requests with a
-structured output format like JSON, or working with binary formats while outputting dynamically generated images. If
-reported errors are displayed at random places in the output it will break the output format, making it invalid and the
-error text may be hard to read. All this will make development and testing very frustrating.
+In some cases displaying errors can break your output making reported errors hard to read. This is why some developers
+may prefer to look at log for errors and disable `display_errors` in the development too. Imagine writing code to
+respond on AJAX requests with a structured output format like JSON, or working with binary formats while outputting
+dynamically generated images. If reported errors are displayed at random places in the output it will break the output
+format, making it invalid and the error text may be hard to read. All this will make development and testing very
+frustrating.
 
 There are browser extensions and third party error reporting handlers to log reported errors from a web application
 directly to the web browser console. This may be used in the development if one finds separate error logging too

--- a/pages/Error-Reporting.md
+++ b/pages/Error-Reporting.md
@@ -29,12 +29,6 @@ logging and `error_log` tells if errors should be logged into a file, to the web
 facility. Another directive `display_errors` configures if reported errors will be displayed in the output (e.g. in
 the web page content).
 
-It is possible to override default error reporting with a custom error handler using the `set_error_handler()` function.
-Many frameworks do have their own error handlers enabled by default. Some PHP extensions may change the default error
-reporting handler to provide more features.
-
-Custom error handler can display fallback content or some error text without sensitive internal details to the user.
-
 For PHP 5.3, it is recommended to set `error_reporting = E_ALL | E_STRICT`.
 
 In PHP 5.4 `E_STRICT` is included in `E_ALL`, so setting `error_reporting = E_ALL` is enough.
@@ -54,6 +48,14 @@ respond on AJAX requests with a structured output format like JSON, or working w
 dynamically generated images. If reported errors are displayed at random places in the output it will break the output
 format, making it invalid and the error text may be hard to read. All this will make development and testing very
 frustrating.
+
+It is possible to override default error reporting with a custom error handler using the `set_error_handler()` function.
+Many frameworks do have their own error handlers enabled by default with different settings for the developing and the
+production environment. Some PHP extensions may change the default error reporting handler to provide more features.
+
+Custom error handler can display fallback content or a custom error text without sensitive internal details to the user.
+There are errors that may be triggered before custom error handler is set in code so you still need to configure
+`display_errors` and other directives as recommended.
 
 There are browser extensions and third party error reporting handlers to log reported errors from a web application
 directly to the web browser console. This may be used in the development if one finds separate error logging too


### PR DESCRIPTION
- Say what is error reporting on the main page
- Add E_ALL | E_STRICT as the recommended error_reporting value for PHP 5.3
- Add missing info on error_log directive
- Do not recommend display_errors = On for development. It will break any complex output.
- Add info on custom error handlers availabile in most frameworks
- Add extended content page on error reporting.

Extended page will also be linked from the upcoming section on Debugging.
