### PR TITLE
Fixed Maruku's warning on "Register globals" section

### DIFF
--- a/_posts/02-01-01-Code-Style-Guide.md
+++ b/_posts/02-01-01-Code-Style-Guide.md
@@ -22,6 +22,12 @@ You can use the [phpcs-psr][phpcs-psr] sniff for [PHP_CodeSniffer][phpcs] to che
 Use Fabien Potencier's [PHP Coding Standards Fixer][phpcsfixer] to automatically modify your code syntax so that it
 conforms with these standards, saving you from fixing each problem by hand.
 
+And last but not least. There's only one language, in which you should write your code - and that rule it's basically the same for almost all programming languages. And that language is **English**. 
+
+Use English names for variables, classes, interfaces, even comments - basically everything, which is not translation files of course ;). Why? Let  me quote an answer from [StackOverflow's question][so]:
+
+> Most (not to say all) of my colleagues are Dutch, like me, however, you never know who will be looking at your code a year from now. I think it's just good practice not to limit your code to people who speak the same language.
+
 [fig]: http://www.php-fig.org/
 [psr0]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
 [psr1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
@@ -29,3 +35,4 @@ conforms with these standards, saving you from fixing each problem by hand.
 [phpcs]: http://pear.php.net/package/PHP_CodeSniffer/
 [phpcs-psr]: https://github.com/klaussilveira/phpcs-psr
 [phpcsfixer]: http://cs.sensiolabs.org/
+[so]: http://stackoverflow.com/questions/440052/should-identifiers-and-comments-be-always-in-english-or-in-the-native-language-o

--- a/_posts/07-06-01-Register-Globals.md
+++ b/_posts/07-06-01-Register-Globals.md
@@ -4,8 +4,7 @@ isChild: true
 
 ## Register Globals
 
-<strong>NOTE:</strong> As of PHP 5.4.0 the `register_globals` setting has been removed and can no 
-longer be used. This is only included as a warning for anyone in the process of upgrading a legacy application.
+**NOTE:** As of PHP 5.4.0 the `register_globals` setting has been removed and can no longer be used. This is only included as a warning for anyone in the process of upgrading a legacy application.
 
 When enabled, the `register_globals` configuration setting that makes several types of variables (including ones from 
 `$_POST`, `$_GET` and `$_REQUEST`) available in the global scope of your application. This can easily lead to 


### PR DESCRIPTION
When `jekyll --server` locally, there's a warning about syntax:

```
Maruku tells you:
+---------------------------------------------------------------------------
| Could you please format this better?
| I see that " As of PHP 5.4.0 the `register_globals` setting has been removed and can no " is left after the raw HTML.
| At line 4
|    header3     |## Register Globals|
|      empty     ||
|   raw_html     |<strong>NOTE:</strong> As of PHP 5.4.0 the `register_globals` setting has been removed and can no |
|       text --> |longer be used. This is only included as a warning for anyone in the process of upgrading a legacy application.|
|      empty     ||
|       text     |When enabled, the `register_globals` configuration setting that makes several types of variables (including ones from |
|       text     |`$_POST`, `$_GET` and `$_REQUEST`) available in the global scope of your application. This can easily lead to |
```
