### PR TITLE
Fixed Maruku's style warning in "Register Globals" chapter

### DIFF
--- a/_posts/07-06-01-Register-Globals.md
+++ b/_posts/07-06-01-Register-Globals.md
@@ -4,7 +4,7 @@ isChild: true
 
 ## Register Globals
 
-<strong>NOTE:</strong> As of PHP 5.4.0 the `register_globals` setting has been removed and can no 
+**NOTE:** As of PHP 5.4.0 the `register_globals` setting has been removed and can no 
 longer be used. This is only included as a warning for anyone in the process of upgrading a legacy application.
 
 When enabled, the `register_globals` configuration setting that makes several types of variables (including ones from 


### PR DESCRIPTION
When `jekyll --server` locally, there's a warning about syntax:

```
Maruku tells you:
+---------------------------------------------------------------------------
| Could you please format this better?
| I see that " As of PHP 5.4.0 the `register_globals` setting has been removed and can no " is left after the raw HTML.
| At line 4
|    header3     |## Register Globals|
|      empty     ||
|   raw_html     |<strong>NOTE:</strong> As of PHP 5.4.0 the `register_globals` setting has been removed and can no |
|       text --> |longer be used. This is only included as a warning for anyone in the process of upgrading a legacy application.|
|      empty     ||
|       text     |When enabled, the `register_globals` configuration setting that makes several types of variables (including ones from |
|       text     |`$_POST`, `$_GET` and `$_REQUEST`) available in the global scope of your application. This can easily lead to |
```
