### PR TITLE
error_reporting can be set to -1 in dev env

### DIFF
--- a/_posts/07-07-01-Error-Reporting.md
+++ b/_posts/07-07-01-Error-Reporting.md
@@ -14,7 +14,7 @@ production (live).
 To show errors in your <strong>development</strong> environment, configure the following settings in your `php.ini`:
 
 - display_errors: On
-- error_reporting: E_ALL
+- error_reporting: -1
 - log_errors: On
 
 ### Production


### PR DESCRIPTION
"Passing in the value -1 will show every possible error, even when new levels and constants are added in future PHP versions. The E_ALL constant also behaves this way as of PHP 5.4."

http://php.net/manual/en/function.error-reporting.php
