### PR TITLE
Changed UK-specific php.net links to be language-agnostic

### DIFF
--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -48,7 +48,7 @@ available as `__call()` and `__callStatic()`.
 * [Read about Reflection][reflection]
 
 [namespaces]: http://php.net/manual/en/language.namespaces.php
-[overloading]: http://uk.php.net/manual/en/language.oop5.overloading.php
+[overloading]: http://php.net/manual/en/language.oop5.overloading.php
 [oop]: http://www.php.net/manual/en/language.oop5.php
 [anonymous-functions]: http://www.php.net/manual/en/functions.anonymous.php
 [closure-class]: http://php.net/manual/en/class.closure.php

--- a/_posts/06-01-01-Databases.md
+++ b/_posts/06-01-01-Databases.md
@@ -81,6 +81,6 @@ Some abstraction layers have been built using the PSR-0 namespace standard so ca
 [4]: http://packages.zendframework.com/docs/latest/manual/en/index.html#zend-db
 [5]: http://php.net/manual/en/pdo.connections.php
 
-[mysql]: http://uk.php.net/mysql
-[mysqli]: http://uk.php.net/mysqli
-[pgsql]: http://uk.php.net/pgsql
+[mysql]: http://php.net/mysql
+[mysqli]: http://php.net/mysqli
+[pgsql]: http://php.net/pgsql


### PR DESCRIPTION
The sections "Databases" and "Programming Paradigms" contain some php.net links that use the uk.php.net subdomain, which forces usage of the en_GB locale. This pull request changes those links to use the root php.net domain so that the user's preferred locale is used instead.
