### PR TITLE
Unified conditional arguments and replaced APC example

### DIFF
--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -22,7 +22,7 @@ Let's write a simple "Hello, $name" CLI program. To try it out, create a file na
 
 {% highlight php %}
 <?php
-if($argc != 2) {
+if ($argc != 2) {
     echo "Usage: php hello.php [name].\n";
     exit(1);
 }

--- a/_posts/05-03-01-Date-and-Time.md
+++ b/_posts/05-03-01-Date-and-Time.md
@@ -16,7 +16,7 @@ output.
 $raw = '22. 11. 1968';
 $start = \DateTime::createFromFormat('d. m. Y', $raw);
 
-echo "Start date: " . $start->format('m/d/Y') . "\n";
+echo 'Start date: ' . $start->format('m/d/Y') . "\n";
 {% endhighlight %}
 
 Calculating with DateTime is possible with the DateInterval class. DateTime has methods like `add()` and `sub()` that
@@ -30,18 +30,18 @@ $end = clone $start;
 $end->add(new \DateInterval('P1M6D'));
 
 $diff = $end->diff($start);
-echo "Difference: " . $diff->format('%m month, %d days (total: %a days)') . "\n";
+echo 'Difference: ' . $diff->format('%m month, %d days (total: %a days)') . "\n";
 // Difference: 1 month, 6 days (total: 37 days)
 {% endhighlight %}
 
 On DateTime objects you can use standard comparison:
 {% highlight php %}
 <?php
-if($start < $end) {
+if ($start < $end) {
     echo "Start is before end!\n";
 }
 {% endhighlight %}
-    
+
 One last example to demonstrate the DatePeriod class. It is used to iterate over recurring events. It can take two
 DateTime objects, start and end, and the interval for which it will return all events in between.
 {% highlight php %}
@@ -49,10 +49,9 @@ DateTime objects, start and end, and the interval for which it will return all e
 // output all thursdays between $start and $end
 $periodInterval = \DateInterval::createFromDateString('first thursday');
 $periodIterator = new \DatePeriod($start, $periodInterval, $end, \DatePeriod::EXCLUDE_START_DATE);
-foreach($periodIterator as $date)
-{
+foreach ($periodIterator as $date) {
     // output each date in the period
-    echo $date->format('m/d/Y') . " ";
+    echo $date->format('m/d/Y') . ' ';
 }
 {% endhighlight %}
 

--- a/_posts/10-03-01-Object-Caching.md
+++ b/_posts/10-03-01-Object-Caching.md
@@ -28,15 +28,12 @@ Example logic using APC:
 {% highlight php %}
 <?php
 // check if there is data saved as 'expensive_data' in cache
-$data = apc_fetch('expensive_data');
-if (!$data)
-{
-    // data not in cache, do expensive call and save for later use
-    $data = get_expensive_data();
-    apc_store('expensive_data', $data);
+if (apc_fetch('expensive_data') === false) {
+    // data is not in cache; save expensive call for later use
+    apc_add('expensive_data', get_expensive_data());
 }
 
-print_r($data);
+print_r(apc_fetch('expensive_data'));
 {% endhighlight %}
 
 Learn more about popular object caching systems:


### PR DESCRIPTION
I noticed that the spacing between conditional arguments was different between users, so I unified all of the code with the following format:

``` php
<?php
if ($a) {

}
```

I also replaced the APC object caching example as I felt it went against the basis of using the cache:

Old:

``` php
<?php
// check if there is data saved as 'expensive_data' in cache
$data = apc_fetch('expensive_data');
if (!$data)
{
    // data not in cache, do expensive call and save for later use
    $data = get_expensive_data();
    apc_store('expensive_data', $data);
}

print_r($data);
```

New:

``` php
<?php
// check if there is data saved as 'expensive_data' in cache
if (apc_fetch('expensive_data') === false) {
    // data is not in cache; save expensive call for later use
    apc_add('expensive_data', get_expensive_data());
}

print_r(apc_fetch('expensive_data'));
```
- apc_fetch returns 'false' on failure, which while not a concern while using '!', it's still best to put across that types should be compared on strict comparisons 
- apc_store will rewrite the previous entry if it exists
- Storing the function's output in '$data' is unnecessary unless we're checking the return value
- The example is suppose to showcase caching, so returning the variable's data didn't seem right

While I'm not 100% happy with my example, I think it's a better representation... Although when using APC, the output should always be confirmed as APC's function's only return true/false (except while fetching).
