### PR TITLE
Equalizing the information at BDD links list.

### DIFF
--- a/_posts/08-03-01-Behavior-Driven-Development.md
+++ b/_posts/08-03-01-Behavior-Driven-Development.md
@@ -17,6 +17,6 @@ by the [RSpec project](http://rspec.info/) for Ruby.
 
 ### BDD Links    
 
-* [Behat](http://behat.org/) is inspired by Ruby's [Cucumber](http://cukes.info/) project 
-* [PHPSpec](http://www.phpspec.net/) the SpecBDD framework for PHP
-* [Codeception](http://www.codeception.com) is a full-stack testing framework that uses BDD principles
+* [Behat](http://behat.org/), the StoryBDD framework for PHP, inspired by Ruby's [Cucumber](http://cukes.info/) project;
+* [PHPSpec](http://www.phpspec.net/), the SpecBDD framework for PHP, inspired by Ruby's [RSpec](http://rspec.info/) project;
+* [Codeception](http://www.codeception.com) is a full-stack testing framework that uses BDD principles.


### PR DESCRIPTION
On the "BDD links" list is important keeping the same level of
information given about each item.

Thus, as the second item of the list shows that PHPSpec is the SpecBDD
implementation for PHP, the first line, about Behat, has been changed
to inform the reader that it is the StoryBDD implementation for PHP.
