### PR TITLE
Fixed w3c validator errors for "Duplicate ID"

### DIFF
--- a/_posts/01-01-01-Getting-Started.md
+++ b/_posts/01-01-01-Getting-Started.md
@@ -1,2 +1,2 @@
-# Getting Started
+# Getting Started {#getting_started_title}
 

--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -3,7 +3,7 @@ title: Use the Current Stable Version (5.4)
 isChild: true
 ---
 
-## Use the Current Stable Version (5.4)
+## Use the Current Stable Version (5.4) {#use_the_current_stable_version_54_title}
 
 If you are just getting started with PHP make sure to start with the current stable release of [PHP 5.4][php-release]. PHP has made great strides adding powerful [new features](#language_highlights) over the last few years. Don't let the minor version number difference between 5.2 and 5.4 fool you, it represents _major_ improvements. If you are looking for a function or it's usage, the documentation on the [php.net][php-docs] website will have the answer.
 

--- a/_posts/01-03-01-Built-in-Web-Server.md
+++ b/_posts/01-03-01-Built-in-Web-Server.md
@@ -3,7 +3,7 @@ title: Built-in Web Server
 isChild: true
 ---
 
-## Built-in web server
+## Built-in web server {#builtin_web_server_title}
 
 You can start learning PHP without the hassle of installing and configuring a full-fledged web server (PHP 5.4 required). To start the server, run the following from your terminal in your project's web root:
 

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Mac Setup
+## Mac Setup  {#mac_setup_title}
 
 OSX comes prepackaged with PHP but it is normally a little behind the latest stable. Lion comes with PHP 5.3.6 and
 Mountain Lion has 5.3.10.

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Windows Setup
+## Windows Setup {#windows_setup_title}
 
 PHP is available in several ways for Windows. You can [download the binaries](php-downloads) and until recently you could use a '.msi' 
 installer. The installer is no longer supported and stops at PHP 5.3.0.

--- a/_posts/02-01-01-Code-Style-Guide.md
+++ b/_posts/02-01-01-Code-Style-Guide.md
@@ -1,4 +1,4 @@
-# Code Style Guide
+# Code Style Guide  {#code_style_guide_title}
 
 The PHP community is large and diverse, composed of innumerable libraries, frameworks, and components. It is common for
 PHP developers to choose several of these and combine them into a single project. It is important that PHP code adhere

--- a/_posts/03-01-01-Language-Highlights.md
+++ b/_posts/03-01-01-Language-Highlights.md
@@ -1,1 +1,1 @@
-# Language Highlights
+# Language Highlights {#language_highlights_title}

--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Programming Paradigms
+## Programming Paradigms {#programming_paradigms_title}
 
 PHP is a flexible, dynamic language that supports a variety of programming techniques. It has evolved dramatically over
 the years, notably adding a solid object-oriented model in PHP 5.0 (2004), anonymous functions and namespaces in PHP 5.3 

--- a/_posts/03-03-01-Namespaces.md
+++ b/_posts/03-03-01-Namespaces.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Namespaces
+## Namespaces {#namespaces_title}
 
 As mentioned above, the PHP community has a lot of developers creating lots of code. This means that one library's PHP code may use the same class name as another library. When both libraries are used in the same namespace, they collide and cause trouble.
 

--- a/_posts/03-04-01-Standard-PHP-Library.md
+++ b/_posts/03-04-01-Standard-PHP-Library.md
@@ -3,7 +3,7 @@ title:   Standard PHP Library
 isChild: true
 ---
 
-## Standard PHP Library
+## Standard PHP Library {#standard_php_library_title}
 
 The Standard PHP Library (SPL) is packaged with PHP and provides a collection of classes and interfaces. It is made up primarily of commonly needed datastructure classes (stack, queue, heap, and so on), and iterators which can traverse over these datastructures or your own classes which implement SPL interfaces.
 

--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Command Line Interface
+## Command Line Interface {#command_line_interface_title}
 
 PHP was created primarily to write web applications, but it's also useful for scripting command line interface (CLI) programs, too. Command line PHP programs can help you automate common tasks like testing, deployment, and application administrativia.
 

--- a/_posts/04-01-01-Dependency-Management.md
+++ b/_posts/04-01-01-Dependency-Management.md
@@ -1,4 +1,4 @@
-# Dependency Management
+# Dependency Management {#dependency_management_title}
 
 There are a ton of PHP libraries, frameworks, and components to choose from. Your project will likely use several of them — these are project dependencies. Until recently, PHP did not have a good way to manage these project dependencies. Even if you managed them manually, you still had to worry about autoloaders. No more.
 

--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Composer and Packagist
+## Composer and Packagist {#composer_and_packagist_title}
 
 Composer is a **brilliant** dependency manager for PHP. List your project's dependencies in a `composer.json` file and, with a few simple commands, Composer will automatically download your project's dependencies and setup autoloading for you.
 

--- a/_posts/04-03-01-PEAR.md
+++ b/_posts/04-03-01-PEAR.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## PEAR
+## PEAR {#pear_title}
 
 Another veteran package manager that many PHP developers enjoy is [PEAR][1]. It behaves much the same way, and is also worth researching for your projects. [Learn about PEAR][1].
 

--- a/_posts/05-01-01-Coding-Practices.md
+++ b/_posts/05-01-01-Coding-Practices.md
@@ -1,1 +1,1 @@
-# Coding Practices
+# Coding Practices {#coding_practices_title}

--- a/_posts/05-02-01-The-Basics.md
+++ b/_posts/05-02-01-The-Basics.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## The Basics
+## The Basics {#the_basics_title}
 
 PHP is a vast language that allows coders of all levels the ability to produce code not only quickly, but efficiently. 
 However while advancing through the language, we often forget the basics that we first learnt (or overlooked) in favor 

--- a/_posts/05-03-01-Date-and-Time.md
+++ b/_posts/05-03-01-Date-and-Time.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Date and Time
+## Date and Time {#date_and_time_title}
 
 PHP has a class named DateTime to help you when reading, writing, comparing or calculating with date and time. There are
 many date and time related functions in PHP besides DateTime, but it provides nice object-oriented interface to most

--- a/_posts/05-04-01-Design-Patterns.md
+++ b/_posts/05-04-01-Design-Patterns.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Design Patterns
+## Design Patterns {#design_patterns_title}
 
 When you are building your application it is helpful to use common patterns in your code and common patterns for the
 overall structure of your project. Using common patterns is helpful because it makes it much easier to manage your code

--- a/_posts/05-05-01-Exceptions.md
+++ b/_posts/05-05-01-Exceptions.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Exceptions
+## Exceptions {#exceptions_title}
 
 Exceptions are a standard part of most popular programming languages, but they are often overlooked by PHP programmers. 
 Languages like Ruby are extremely Exception heavy, so whenever something goes wrong such as a HTTP request failing, or 

--- a/_posts/06-01-01-Databases.md
+++ b/_posts/06-01-01-Databases.md
@@ -2,7 +2,7 @@
 title: Databases
 ---
 
-# Databases
+# Databases {#databases_title}
 
 Many times your PHP code will use a database to persist information. You have a few options to connect and interact
 with your database. The recommended option _until PHP 5.1.0_ was to use native drivers such as [mysql][mysql], [mysqli][mysqli], [pgsql][pgsql], etc.

--- a/_posts/07-01-01-Security.md
+++ b/_posts/07-01-01-Security.md
@@ -1,1 +1,1 @@
-# Security
+# Security {#security_title}

--- a/_posts/07-02-01-Web-Application-Security.md
+++ b/_posts/07-02-01-Web-Application-Security.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Web Application Security
+## Web Application Security {#web_application_security_title}
 
 There are bad people ready and willing to exploit your web application. It is important that you
  take necessary precautions to harden your web application's security. Luckily, the fine folks at [The Open Web Application Security Project][1] (OWASP) have compiled a comprehensive list of known security issues and methods to protect yourself against them. This is a must read for the security-conscious developer.

--- a/_posts/07-03-01-Password-Hashing-with-Bcrypt.md
+++ b/_posts/07-03-01-Password-Hashing-with-Bcrypt.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Password Hashing with Bcrypt
+## Password Hashing with Bcrypt {#password_hashing_with_bcrypt_title}
 
 Eventually everyone builds a PHP application that relies on user login. Usernames and (hashed) passwords are stored in a database and later used to authenticate users upon login.
 

--- a/_posts/07-04-01-Data-Filtering.md
+++ b/_posts/07-04-01-Data-Filtering.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Data Filtering
+## Data Filtering {#data_filtering_title}
 
 Never ever (ever) trust foreign input introduced to your PHP code. Always sanitize and validate
 foreign input before using it in code. The `filter_var` and `filter_input` functions can sanitize text and validate text formats (e.g.

--- a/_posts/07-05-01-Configuration-Files.md
+++ b/_posts/07-05-01-Configuration-Files.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Configuration Files
+## Configuration Files {#configuration_files_title}
 
 When creating configuration files for your applications, best practices recommend that one of the following methods 
 be followed:

--- a/_posts/07-06-01-Register-Globals.md
+++ b/_posts/07-06-01-Register-Globals.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Register Globals
+## Register Globals {#register_globals_title}
 
 **NOTE:** As of PHP 5.4.0 the `register_globals` setting has been removed and can no 
 longer be used. This is only included as a warning for anyone in the process of upgrading a legacy application.

--- a/_posts/07-07-01-Error-Reporting.md
+++ b/_posts/07-07-01-Error-Reporting.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Error Reporting
+## Error Reporting {#error_reporting_title}
 
 Error logging can be useful in finding the problem spots in your application, but it can also expose information about 
 the structure of your application to the outside world. To effectively protect your application from issues that could 

--- a/_posts/08-01-01-Testing.md
+++ b/_posts/08-01-01-Testing.md
@@ -1,4 +1,4 @@
-# Testing
+# Testing {#testing_title}
 
 Writing automated tests for your PHP code is considered a best practice and can lead to well-built
 applications. Automated tests are a great tool for making sure your application

--- a/_posts/08-02-01-Test-Driven-Development.md
+++ b/_posts/08-02-01-Test-Driven-Development.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Test Driven Development
+## Test Driven Development {#test_driven_development_title}
 
 From [Wikipedia](http://en.wikipedia.org/wiki/Test-driven_development):
 

--- a/_posts/08-03-01-Behavior-Driven-Development.md
+++ b/_posts/08-03-01-Behavior-Driven-Development.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Behavior Driven Development
+## Behavior Driven Development {#behavior_driven_development_title}
 
 There are two different types of Behavior-Driven Development (BDD): SpecBDD and StoryBDD. SpecBDD focuses on technical behavior or code, while StoryBDD focuses on business or feature behaviors or interactions. PHP has frameworks for both types of BDD.
 

--- a/_posts/08-04-01-Complementary-Testing-Tools.md
+++ b/_posts/08-04-01-Complementary-Testing-Tools.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Complementary Testing Tools
+## Complementary Testing Tools {#complementary_testing_tools_title}
 
 Besides individual testing and behavior driven frameworks, there are also a number of generic frameworks and helper libraries useful for any preferred approach taken.
 

--- a/_posts/09-01-01-Servers-and-Deployment.md
+++ b/_posts/09-01-01-Servers-and-Deployment.md
@@ -1,3 +1,3 @@
-# Servers and Deployment
+# Servers and Deployment {#servers_and_deployment_title}
 
 PHP applications can be deployed and run on production web servers in a number of ways.

--- a/_posts/09-02-01-Platform-as-a-Service.md
+++ b/_posts/09-02-01-Platform-as-a-Service.md
@@ -3,7 +3,7 @@ title: Platform as a Service (PaaS)
 isChild: true
 ---
 
-## Platform as a Service (PaaS) 
+## Platform as a Service (PaaS)  {#platform_as_a_service_paas_title}
 
 PaaS provides the system and network architecture necessary to run PHP applications on the web. This means little to no 
 configuration for launching PHP applications or PHP frameworks. 

--- a/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/09-03-01-Virtual-or-Dedicated-Servers.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Virtual or Dedicated Servers
+## Virtual or Dedicated Servers {#virtual_or_dedicated_servers_title}
 
 If you are comfortable with systems administration, or are interested in learning it, virtual or dedicated servers give you complete control of your application's production environment.
 

--- a/_posts/09-04-01-Shared-Servers.md
+++ b/_posts/09-04-01-Shared-Servers.md
@@ -2,6 +2,6 @@
 isChild: true
 ---
 
-## Shared Servers
+## Shared Servers {#shared_servers_title}
 
 PHP has shared servers to thank for its popularity. It is hard to find a host without PHP installed, but be sure it's the latest version. Shared servers allow you and other developers to deploy websites to a single machine. The upside to this is that it has become a cheap commodity. The downside is that you never know what kind of a ruckus your neighboring tenants are going to create; loading down the server or opening up security holes are the main concerns. If your project's budget can afford to avoid shared servers you should.

--- a/_posts/10-01-01-Caching.md
+++ b/_posts/10-01-01-Caching.md
@@ -1,4 +1,4 @@
-# Caching
+# Caching {#caching_title}
 
 PHP is pretty quick by itself, but bottlenecks can arise when you make remote connections, load files, etc. 
 Thankfully, there are various tools available to speed up certain parts of your application, or reduce the number of times these various time consuming tasks need to run.

--- a/_posts/10-02-01-Bytecode-Cache.md
+++ b/_posts/10-02-01-Bytecode-Cache.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Bytecode Cache
+## Bytecode Cache {#bytecode_cache_title}
 
 When a PHP file is executed, under the hood it is first compiled to bytecode (also known as opcode) and, only then, the bytecode is executed.
 If a PHP file is not modified, the bytecode will always be the same. This means that the compilation step is a waste of CPU resources.

--- a/_posts/10-03-01-Object-Caching.md
+++ b/_posts/10-03-01-Object-Caching.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Object Caching
+## Object Caching {#object_caching_title}
 
 There are times when it can be beneficial to cache individual objects in your code, such as with data that is expensive
 to get or database calls where the result is unlikely to change. You can use object caching software to hold these

--- a/_posts/11-01-01-Resources.md
+++ b/_posts/11-01-01-Resources.md
@@ -1,4 +1,4 @@
-# Resources
+# Resources {#resources_title}
 
 ## From the Source
 

--- a/_posts/11-02-01-Frameworks.md
+++ b/_posts/11-02-01-Frameworks.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Frameworks
+## Frameworks {#frameworks_title}
 
 Rather than re-invent the wheel, many PHP developers use frameworks to build out web applications. Frameworks abstract away many of the low-level concerns and provide helpful, easy-to-use interfaces to complete common tasks.
 

--- a/_posts/11-03-01-Components.md
+++ b/_posts/11-03-01-Components.md
@@ -2,7 +2,7 @@
 isChild: true
 ---
 
-## Components
+## Components {#components_title}
 
 As mentioned above "Components" are another approach to the common goal of creating, distributing and implementing shared code. Various 
 component repositories exist, the main two of which are:

--- a/_posts/12-01-01-Community.md
+++ b/_posts/12-01-01-Community.md
@@ -1,4 +1,4 @@
-# Community
+# Community {#community_title}
 
 The PHP community is as diverse as it is large, and it's members are ready and willing to support new PHP programmers. You should consider joining your local PHP user group (PUG) or attending larger PHP conferences to learn more about the best practices shown here. You can also hang out on IRC in the #phpc channel on irc.freenode.com and follow the [@phpc][phpc-twitter] twitter account. Get out there, meet new developers, learn new topics and, above all, make new friends.
 


### PR DESCRIPTION
Maruku produces duplicate ids for div and h1/h2. http://validator.w3.org/check?uri=http%3A%2F%2Fwww.phptherightway.com%2F

This is a workaround till Maruku fixes the bug. If someone skilled in Ruby could fix it we could revert back this change
