### PR TITLE
Remove "too" from "also...too"

### DIFF
--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -4,7 +4,7 @@ isChild: true
 
 ## Command Line Interface
 
-PHP was created primarily to write web applications, but it's also useful for scripting command line interface (CLI) programs, too. Command line PHP programs can help you automate common tasks like testing, deployment, and application administrativia.
+PHP was created primarily to write web applications, but it's also useful for scripting command line interface (CLI) programs. Command line PHP programs can help you automate common tasks like testing, deployment, and application administrativia.
 
 CLI PHP programs are powerful because you can use your app's code directly without having to create and secure a web GUI for it. Just be sure not to put your CLI PHP scripts in your public web root!
 


### PR DESCRIPTION
In the section on CLI, a sentence contains both "also" and "too". Fixed in this repo.
