### PR TITLE
Suggested change to Cross-Site Scripting Mitigation.

### DIFF
--- a/_posts/07-04-01-Data-Filtering.md
+++ b/_posts/07-04-01-Data-Filtering.md
@@ -19,8 +19,10 @@ the data is filtered properly and can it be trusted.
 
 Data may be _filtered_ differently based on its purpose. For example, when unfiltered foreign input is passed
 into HTML page output, it can execute HTML and JavaScript on your site! This is known as Cross-Site
-Scripting (XSS) and can be a very dangerous attack. One way to avoid XSS is to sanitize all HTML tags
-in the input by removing tags or escaping them into HTML entities.
+Scripting (XSS) and can be a very dangerous attack. One way to avoid XSS is to sanitize all user-generated
+data before outputting it to your page by removing HTML tags with the `strip_tags` function or escaping
+characters with special meaning into their respective HTML entities with the `htmlentities`
+or `htmlspecialchars` functions.
 
 Another example is passing options to be executed on the command line. This can be extremely dangerous
 (and is usually a bad idea), but you can use the built-in `escapeshellarg` function to sanitize the executed


### PR DESCRIPTION
Previous wording read like it suggested to always filter user input by stripping/escaping. This is not true while storing data.

This patch tries to change the paragraph to say that stripping/escaping should only take place before outputting data to the page.
