### PR TITLE
Use HTTPS when installing composer

### DIFF
--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -12,7 +12,7 @@ There are already a lot of PHP libraries that are compatible with Composer, read
 
 You can install Composer locally (in your current working directory; though this is no longer recommended) or globally (e.g. /usr/local/bin). Let's assume you want to install Composer locally. From your project's root directory:
 
-    curl -s http://getcomposer.org/installer | php
+    curl -s https://getcomposer.org/installer | php
 
 This will download `composer.phar` (a PHP binary archive). You can run this with `php` to manage your project dependencies. <strong>Please Note:</strong> If you pipe downloaded code directly into an interpreter, please read the code online first to confirm it is safe.
 
@@ -28,7 +28,7 @@ Manually installing composer is an advanced technique; however, there are variou
 
 Since a manual installation performs none of these checks, you have to decide whether the trade-off is worth it for you. As such, below is how to obtain Composer manually:
 
-    curl -s http://getcomposer.org/composer.phar -o $HOME/local/bin/composer
+    curl -s https://getcomposer.org/composer.phar -o $HOME/local/bin/composer
     chmod +x $HOME/local/bin/composer
 
 The path `$HOME/local/bin` (or a directory of your choice) should be in your `$PATH` environment variable. This will result in a `composer` command being available.


### PR DESCRIPTION
getcomposer.org has SSL set up. Since it's being used to download and install Composer directly, we may as well recommend users use SSL to install the package. It doesn't ensure the actual file is valid if it's been changed on the server, but does will prevent any MITM attacks against installing composer.
