### PR TITLE
Added links to bg.phptherightway.com for Bulgarian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ developers know where to find good information!
 * [Chinese](http://wulijun.github.com/php-the-right-way)
 * [Ukrainian](http://iflista.github.com/php-the-right-way)
 * [Portuguese](http://br.phptherightway.com/)
+* [Bulgarian](http://bg.phptherightway.com/)
 
 ### Translations
 

--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -16,6 +16,7 @@ _PHP: The Right Way_ is (or soon will be) translated into many different languag
 * Russian (Coming Soon)
 * [Spanish](http://es.phptherightway.com)
 * [Ukrainian](http://iflista.github.com/php-the-right-way/)
+* [Bulgarian](http://bg.phptherightway.com/)
 
 ## Disclaimer
 


### PR DESCRIPTION
The CNAME in the Bulgarian translation is set to bg.phptherightway.com
The links are currently dead because there is no bg. subdomain to the phptherightway.com DNS zone.
