### PR TITLE
Resources / PHP PaaS Providers

### DIFF
--- a/_posts/11-01-01-Resources.md
+++ b/_posts/11-01-01-Resources.md
@@ -25,7 +25,7 @@
 
 * [PagodaBox](https://pagodabox.com/)
 * [AppFog](https://appfog.com/)
-* [fortrabbit](https://fortrabbit.com/)
+* [fortrabbit](http://fortrabbit.com/)
 * [Engine Yard Orchestra PHP Platform](http://www.engineyard.com/products/orchestra/)
 * [Red Hat OpenShift Platform](http://www.redhat.com/products/cloud-computing/openshift/)
 * [dotCloud](http://docs.dotcloud.com/services/php/)

--- a/_posts/11-01-01-Resources.md
+++ b/_posts/11-01-01-Resources.md
@@ -24,7 +24,8 @@
 ## PHP PaaS Providers
 
 * [PagodaBox](https://pagodabox.com/)
-* [PHP Fog](https://phpfog.com/)
+* [AppFog](https://appfog.com/)
+* [fortrabbit](https://fortrabbit.com/)
 * [Engine Yard Orchestra PHP Platform](http://www.engineyard.com/products/orchestra/)
 * [Red Hat OpenShift Platform](http://www.redhat.com/products/cloud-computing/openshift/)
 * [dotCloud](http://docs.dotcloud.com/services/php/)


### PR DESCRIPTION
phpfog.com will discontinue the service at the end of the year.
Added: AppFog and fortrabbit
