### PR TITLE
Fix incorrect links

### DIFF
--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -70,5 +70,6 @@ The [Security Advisories Checker][3] is a web service and a command-line tool, b
 
 [1]: http://packagist.org/
 [2]: http://twig.sensiolabs.org
-[3]: http://getcomposer.org/doc/00-intro.md
-[4]: https://security.sensiolabs.org/
+[3]: https://security.sensiolabs.org/
+[4]: http://getcomposer.org/doc/00-intro.md
+


### PR DESCRIPTION
The "read more about composer" and "sensiolabs security checker" links were accidentally reversed. 
