### PR TITLE
Adding PHPCI to the continuous integration section.

### DIFF
--- a/_posts/09-05-01-Building your Application.md
+++ b/_posts/09-05-01-Building your Application.md
@@ -71,4 +71,5 @@ languages including PHP.
 Further reading:
 
 * [Continuous Integration with Jenkins](http://jenkins-ci.org/)
+* [Continuous Integration with PHPCI](http://www.phptesting.org/)
 * [Continuous Integration with Teamcity](http://www.jetbrains.com/teamcity/)


### PR DESCRIPTION
We've just released PHPCI: http://www.phptesting.org/ - and we think it is a great tool to get PHP developers quickly up and running with CI on their not-necessarily open source projects. 

I hope you can consider adding it to the site. :)
