### PR TITLE
Removing \ from global functions

### DIFF
--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -82,7 +82,7 @@ class Singleton
     {
         static $instance = null;
         if (null === $instance) {
-            $instance = new static;
+            $instance = new static();
         }
 
         return $instance;

--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -122,12 +122,12 @@ class SingletonChild extends Singleton
 }
 
 $obj = Singleton::getInstance();
-\var_dump($obj === Singleton::getInstance());             // bool(true)
+var_dump($obj === Singleton::getInstance());             // bool(true)
 
 $anotherObj = SingletonChild::getInstance();
-\var_dump($anotherObj === Singleton::getInstance());      // bool(false)
+var_dump($anotherObj === Singleton::getInstance());      // bool(false)
 
-\var_dump($anotherObj === SingletonChild::getInstance()); // bool(true)
+var_dump($anotherObj === SingletonChild::getInstance()); // bool(true)
 {% endhighlight %}
 
 The code above implements the singleton pattern using a [*static* variable](http://php.net/language.variables.scope#language.variables.scope.static) and the static creation method `getInstance()`.
@@ -135,7 +135,7 @@ Note the following:
 
 * The constructor [`__construct`](http://php.net/language.oop5.decon#object.construct) is declared as protected to prevent creating a new instance outside of the class via the `new` operator.
 * The magic method [`__clone`](http://php.net/language.oop5.cloning#object.clone) is declared as private to prevent cloning of an instance of the class via the [`clone`](http://php.net/language.oop5.cloning) operator.
-* The magic method [`__wakeup`](http://php.net/language.oop5.magic#object.wakeup) is declared as private to prevent unserializing of an instance of the class via the global function [`\unserialize()`](http://php.net/function.unserialize).
+* The magic method [`__wakeup`](http://php.net/language.oop5.magic#object.wakeup) is declared as private to prevent unserializing of an instance of the class via the global function [`unserialize()`](http://php.net/function.unserialize).
 * A new instance is created via [late static binding](http://php.net/language.oop5.late-static-bindings) in the static creation method `getInstance()` with the keyword `static`. This allows the subclassing of the class `Singleton` in the example.
 
 The singleton pattern is useful when we need to make sure we only have a single instance of a class for the entire


### PR DESCRIPTION
As per my message on:

https://github.com/codeguy/php-the-right-way/commit/78b8adc0157bb6b7aba55651a46f0d4adf46a179

Calls to global functions like var_dump don't need the \ prefix. It's only necessary to do this if you're using namespaces (this example doesn't) and you have a method that clashes with the global one. In this guide I think the \ prefix is confusing to users unfamiliar with namespaces so I suggest they are removed. 

I've also included a minor amend to add parentheses after the instantiation of the singleton object to make this code a bit more obvious to users.

best wishes,
Si
