### PR TITLE
Finally Block and Change of Tense on Referring to Password_hash

### DIFF
--- a/_posts/05-05-01-Exceptions.md
+++ b/_posts/05-05-01-Exceptions.md
@@ -38,6 +38,10 @@ catch(Fuel\Email\SendingFailedException $e)
 {
     // The driver could not send the email
 }
+finally
+{
+    // Use this to let user know email was sent
+}
 {% endhighlight %}
 
 ### SPL Exceptions

--- a/_posts/07-03-01-Password-Hashing.md
+++ b/_posts/07-03-01-Password-Hashing.md
@@ -10,7 +10,7 @@ It is important that you properly [_hash_][3] passwords before storing them. Pas
 
 **Hashing passwords with `password_hash`**
 
-In PHP 5.5 `password_hash` will be introduced. At this time it is using BCrypt, the strongest algorithm currently supported by PHP. It will be updated in the future to support more algorithms as needed though. The `password_compat` library was created to provide forward compatibility for PHP >= 5.3.7.
+In PHP 5.5 `password_hash` was be introduced. At this time it is using BCrypt, the strongest algorithm currently supported by PHP. It will be updated in the future to support more algorithms as needed though. The `password_compat` library was created to provide forward compatibility for PHP >= 5.3.7.
 
 Below we hash a string, we then check the hash against a new string. Because our two source strings are different ('secret-password' vs. 'bad-password') this login will fail. 
 

--- a/_posts/07-03-01-Password-Hashing.md
+++ b/_posts/07-03-01-Password-Hashing.md
@@ -10,7 +10,7 @@ It is important that you properly [_hash_][3] passwords before storing them. Pas
 
 **Hashing passwords with `password_hash`**
 
-In PHP 5.5 `password_hash` was be introduced. At this time it is using BCrypt, the strongest algorithm currently supported by PHP. It will be updated in the future to support more algorithms as needed though. The `password_compat` library was created to provide forward compatibility for PHP >= 5.3.7.
+In PHP 5.5 `password_hash` was introduced. At this time it is using BCrypt, the strongest algorithm currently supported by PHP. It will be updated in the future to support more algorithms as needed though. The `password_compat` library was created to provide forward compatibility for PHP >= 5.3.7.
 
 Below we hash a string, we then check the hash against a new string. Because our two source strings are different ('secret-password' vs. 'bad-password') this login will fail. 
 


### PR DESCRIPTION
Adds finally block to a try-catch statement
Switches tense when referring to the new password_hash function
