### PR TITLE
Updated Engine Yard Resource link

### DIFF
--- a/_posts/11-01-01-Resources.md
+++ b/_posts/11-01-01-Resources.md
@@ -28,7 +28,7 @@
 * [Heroku](https://heroku.com)
   (PHP support is undocumented but based on stable Facebook partnership [link](http://net.tutsplus.com/tutorials/php/quick-tip-deploy-php-to-heroku-in-seconds/))
 * [fortrabbit](http://fortrabbit.com/)
-* [Engine Yard Orchestra PHP Platform](http://www.engineyard.com/products/orchestra/)
+* [Engine Yard Cloud](https://www.engineyard.com/products/cloud)
 * [Red Hat OpenShift Platform](http://www.redhat.com/products/cloud-computing/openshift/)
 * [dotCloud](http://docs.dotcloud.com/services/php/)
 * [AWS Elastic Beanstalk](http://aws.amazon.com/elasticbeanstalk/)


### PR DESCRIPTION
Engine Yard Orchestra has been replaced by the main Engine Yard Cloud platform, which now supports PHP 5.4 and Composer.
