### PR TITLE
Misleading comment in finally block

### DIFF
--- a/_posts/07-03-01-Exceptions.md
+++ b/_posts/07-03-01-Exceptions.md
@@ -40,7 +40,7 @@ catch(Fuel\Email\SendingFailedException $e)
 }
 finally
 {
-    // Use this to let user know email was sent
+    // Executed regardless of whether an exception has been thrown, and before normal execution resumes
 }
 {% endhighlight %}
 


### PR DESCRIPTION
The comment in the finally block is misleading, this may confuse someone unfamiliar with the finally block that it is only executed if no exception was thrown.

Proposed replacement with snippet from the PHP Manual.
