### PR TITLE
Link to openshift fixed

### DIFF
--- a/_posts/13-01-01-Resources.md
+++ b/_posts/13-01-01-Resources.md
@@ -29,7 +29,7 @@
   (PHP support is undocumented but based on stable Facebook partnership [link](http://net.tutsplus.com/tutorials/php/quick-tip-deploy-php-to-heroku-in-seconds/))
 * [fortrabbit](http://fortrabbit.com/)
 * [Engine Yard Cloud](https://www.engineyard.com/products/cloud)
-* [Red Hat OpenShift Platform](http://www.redhat.com/products/cloud-computing/openshift/)
+* [Red Hat OpenShift Platform](http://openshift.com)
 * [dotCloud](http://docs.dotcloud.com/services/php/)
 * [AWS Elastic Beanstalk](http://aws.amazon.com/elasticbeanstalk/)
 * [cloudControl](https://www.cloudcontrol.com/)


### PR DESCRIPTION
Current link to Red Hat OpenShift platform is not working. I've added link to OpenShift.com website instead.
