### PR TITLE
Coding style fix

### DIFF
--- a/_posts/07-01-01-Databases.md
+++ b/_posts/07-01-01-Databases.md
@@ -45,7 +45,7 @@ which will delete all of your users! Instead, you should sanitize the ID input u
 <?php
 $pdo = new PDO('sqlite:users.db');
 $stmt = $pdo->prepare('SELECT name FROM users WHERE id = :id');
-$stmt->bindParam(':id', $_GET['id'], PDO::PARAM_INT); //<-- Automatically sanitized by PDO
+$stmt->bindParam(':id', $_GET['id'], PDO::PARAM_INT); // <-- Automatically sanitized by PDO
 $stmt->execute();
 {% endhighlight %}
 

--- a/_posts/09-03-01-Password-Hashing.md
+++ b/_posts/09-03-01-Password-Hashing.md
@@ -22,9 +22,9 @@ require 'password.php';
 $passwordHash = password_hash('secret-password', PASSWORD_DEFAULT);
 
 if (password_verify('bad-password', $passwordHash)) {
-    //Correct Password
+    // Correct Password
 } else {
-    //Wrong password
+    // Wrong password
 }
 {% endhighlight %}  
 


### PR DESCRIPTION
PHP one line comments have everywhere space after on phptherightway.com. This fixes two typos in Password Hashing.
I updated this PR from https://github.com/codeguy/php-the-right-way/pull/308
I had some merging issues with files renamed ...
Thanks.
