### PR TITLE
Adding Information about "Scream"

### DIFF
--- a/_posts/08-02-01-Errors.md
+++ b/_posts/08-02-01-Errors.md
@@ -89,9 +89,28 @@ for existence of the file before you try to load it, but if the file is deleted 
 potentially something PHP should resolve, but is one case where error suppression might seem like the only valid 
 solution.
 
+In a stock PHP system, the behavior of the error control operator is irreversible. There are no configuration settings which allow a suppressed error to be temporarily un-suppressed.  
+
+However, [xDebug] has an `xdebug.scream` ini setting which will disable the error control operator.  You can set this via your `php.ini` file with the following.
+
+    xdebug.scream = On
+    
+You can also set this value at runtime with the `ini_set` function 
+
+{% highlight php %}
+ini_set('xdebug.scream', '1')
+{% endhighlight %}
+
+The "[Scream]" PHP extension offers similar functionality to xDebug's, although Scream's ini setting is named `scream.enabled`.
+
+This is most useful when you're you're debugging code and suspect an informative  error is suppressed.  Use scream with care, and as a temporary debugging tool. There's lots of PHP library code that may not work with the error control operator disabled.  
+
+
 * [Error Control Operators](http://php.net/manual/en/language.operators.errorcontrol.php)
 * [SitePoint](http://www.sitepoint.com/)
 * [never suppress notices](http://www.sitepoint.com/why-suppressing-notices-is-wrong/)
+* [xDebug](http://xdebug.org/docs/basic) 
+* [Scream](http://www.php.net/manual/en/book.scream.php)
 
 ### ErrorException
 

--- a/_posts/08-02-01-Errors.md
+++ b/_posts/08-02-01-Errors.md
@@ -103,7 +103,7 @@ ini_set('xdebug.scream', '1')
 
 The "[Scream]" PHP extension offers similar functionality to xDebug's, although Scream's ini setting is named `scream.enabled`.
 
-This is most useful when you're you're debugging code and suspect an informative  error is suppressed.  Use scream with care, and as a temporary debugging tool. There's lots of PHP library code that may not work with the error control operator disabled.  
+This is most useful when you're debugging code and suspect an informative error is suppressed.  Use scream with care, and as a temporary debugging tool. There's lots of PHP library code that may not work with the error control operator disabled.  
 
 
 * [Error Control Operators](http://php.net/manual/en/language.operators.errorcontrol.php)


### PR DESCRIPTION
Added a few paragraphs about the "Scream" extension, and `xdebug.scream` as a method for disabling the error control operator. 
