### PR TITLE
Add return to main page link at bottom of page layout.

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -39,6 +39,7 @@
         <div class="interior-site-content">
             <div class="pbh"><em>You are reading extended content about&hellip;</em></div>
             {{ content }}
+            <a href="/">Return to Main Page</a>
             <footer class="site-footer" id="site-footer">
                 <p>
                     <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc-sa/3.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">PHP: The Right Way</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://www.twitter.com/codeguy" property="cc:attributionName" rel="cc:attributionURL">Josh Lockhart</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/3.0/">Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://www.phptherightway.com" rel="dct:source">www.phptherightway.com</a>.


### PR DESCRIPTION
Very simple addition to the bottom of the page layout. I find it quite unnecessary to have to scroll all the way to the top again just to return to the home page.

Note: There really is no styling associated with this change, so that might need to happen before accepting. Let me know if you have a preference and I can commit that change.
