### PR TITLE
Kramdown syntax class name fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ description: "An easy-to-read, quick reference for PHP best practices, accepted 
 {% capture welcome_content %}{% include welcome.md %}{% endcapture %}
 {{ welcome_content|markdownify }}
 
-{% capture backtotop %}[Back to Top](#top){.top}{% endcapture %}
+{% capture backtotop %}[Back to Top](#top){:.top}{% endcapture %}
 {% for post in site.posts reversed %}
     {% if post.isChild != true and loop.first != true %}
     {{ backtotop|markdownify }}


### PR DESCRIPTION
Back to top button does not work properly. This patch fixes this.
