### PR TITLE
Improve to the templating section

### DIFF
--- a/_posts/08-01-01-Templating.md
+++ b/_posts/08-01-01-Templating.md
@@ -7,6 +7,6 @@ anchor: templating
 
 Templates provide a convenient way of separating your controller and domain logic from your presentation logic.
 Templates typically contain the HTML of your application, but may also be used for other formats, such as XML.
-Templates are often referred to as "views", the second component of the
+Templates are often referred to as “views”, which make up **part of** the second component of the
 [model–view–controller](http://www.phptherightway.com/pages/Design-Patterns.html#model-view-controller) (MVC)
 software architecture pattern.

--- a/_posts/08-01-01-Templating.md
+++ b/_posts/08-01-01-Templating.md
@@ -7,6 +7,6 @@ anchor: templating
 
 Templates provide a convenient way of separating your controller and domain logic from your presentation logic.
 Templates typically contain the HTML of your application, but may also be used for other formats, such as XML.
-Templates are often referred to as “views”, which make up **part of** the second component of the
+Templates are often referred to as "views", which make up **part of** the second component of the
 [model–view–controller](http://www.phptherightway.com/pages/Design-Patterns.html#model-view-controller) (MVC)
 software architecture pattern.

--- a/_posts/08-02-01-Benefits.md
+++ b/_posts/08-02-01-Benefits.md
@@ -13,8 +13,8 @@ the client-side code (markup).
 
 Templates also improve the organization of presentation code. Templates are typically placed in a "views" folder, each
 defined within a single file. This approach encourages code reuse where larger blocks of code are broken into smaller,
-reusable pieces. For example, your site header and footer can each be defined as templates, which are then included
-before and after each page template.
+reusable pieces, often called partials. For example, your site header and footer can each be defined as templates,
+which are then included before and after each page template.
 
 Finally, depending on the library you use, templates can offer more security by automatically escaping user-generated
 content. Some libraries even offer sand-boxing, where template designers are only given access to white-listed

--- a/_posts/08-03-01-Plain-PHP-Templates.md
+++ b/_posts/08-03-01-Plain-PHP-Templates.md
@@ -16,13 +16,47 @@ frameworks, libraries like [Plates](http://platesphp.com/) or [Aura.View](https:
 working with plain PHP templates easier by offering modern template functionality such as inheritance, layouts and
 extensions.
 
-Example of a plain PHP template (using the [Plates](http://platesphp.com/) library):
+### Simple example of a plain PHP template
+
+Using the [Plates](http://platesphp.com/) library.
 
 {% highlight php %}
+<?php // user_profile.php ?>
+
 <?php $this->insert('header', ['title' => 'User Profile']) ?>
 
 <h1>User Profile</h1>
 <p>Hello, <?=$this->escape($name)?></p>
 
 <?php $this->insert('footer') ?>
+{% endhighlight %}
+
+### Example of plain PHP templates using inheritance
+
+Using the [Plates](http://platesphp.com/) library.
+
+{% highlight php %}
+<?php // template.php ?>
+
+<html>
+<head>
+    <title><?=$title?></title>
+</head>
+<body>
+
+<main>
+    <?=$this->section('content')?>
+</main>
+
+</body>
+</html>
+{% endhighlight %}
+
+{% highlight php %}
+<?php // user_profile.php ?>
+
+<?php $this->layout('template', ['title' => 'User Profile']) ?>
+
+<h1>User Profile</h1>
+<p>Hello, <?=$this->escape($name)?></p>
 {% endhighlight %}

--- a/_posts/08-04-01-Compiled-Templates.md
+++ b/_posts/08-04-01-Compiled-Templates.md
@@ -7,14 +7,18 @@ anchor: compiled_templates
 
 While PHP has evolved into a mature, object oriented language, it
 [hasn't improved much](http://fabien.potencier.org/article/34/templating-engines-in-php) as a templating language.
-Compiled templates, like [Twig](http://twig.sensiolabs.org/) or [Smarty](http://www.smarty.net/), fill this void by
+Compiled templates, like [Twig](http://twig.sensiolabs.org/) or [Smarty](http://www.smarty.net/)*, fill this void by
 offering a new syntax that has been geared specifically to templating. From automatic escaping, to inheritance and
 simplified control structures, compiled templates are designed to be easier to write, cleaner to read and safer to use.
 Compiled templates can even be shared across different languages, [Mustache](http://mustache.github.io/) being a good
 example of this. Since these templates must be compiled there is a slight performance hit, however this is very minimal
 when proper caching is used.
 
-Example of a compiled template (using the [Twig](http://twig.sensiolabs.org/) library):
+**While Smarty offers automatic escaping, this feature is NOT enabled by default.*
+
+### Simple example of a compiled template
+
+Using the [Twig](http://twig.sensiolabs.org/) library.
 
 {% highlight text %}
 {% raw %}
@@ -24,5 +28,42 @@ Example of a compiled template (using the [Twig](http://twig.sensiolabs.org/) li
 <p>Hello, {{ name }}</p>
 
 {% include 'footer.html' %}
+{% endraw %}
+{% endhighlight %}
+
+### Example of compiled templates using inheritance
+
+Using the [Twig](http://twig.sensiolabs.org/) library.
+
+{% highlight text %}
+{% raw %}
+// template.php
+
+<html>
+<head>
+    <title>{% block title %}{% endblock %}</title>
+</head>
+<body>
+
+<main>
+    {% block content %}{% endblock %}
+</main>
+
+</body>
+</html>
+{% endraw %}
+{% endhighlight %}
+
+{% highlight text %}
+{% raw %}
+// user_profile.php
+
+{% extends "template.html" %}
+
+{% block title %}User Profile{% endblock %}
+{% block content %}
+    <h1>User Profile</h1>
+    <p>Hello, {{ name }}</p>
+{% endblock %}
 {% endraw %}
 {% endhighlight %}


### PR DESCRIPTION
- Add inheritance examples
- Add the word "partials" to better describe reusable pieces of code
- Clarify the role of templates (views) in the MVC pattern
- Add note of caution around Smarty auto escaping

See #414 for more details.
