### PR TITLE
Heroku supports PHP. Fix link.

### DIFF
--- a/_posts/14-01-01-Resources.md
+++ b/_posts/14-01-01-Resources.md
@@ -29,8 +29,7 @@ anchor: resources
 
 * [PagodaBox](https://pagodabox.com/)
 * [AppFog](https://appfog.com/)
-* [Heroku](https://heroku.com)
-  (PHP support is undocumented but based on stable Facebook partnership [link](http://net.tutsplus.com/tutorials/php/quick-tip-deploy-php-to-heroku-in-seconds/))
+* [Heroku](https://devcenter.heroku.com/categories/php)
 * [fortrabbit](http://fortrabbit.com/)
 * [Engine Yard Cloud](https://www.engineyard.com/products/cloud)
 * [Red Hat OpenShift Platform](http://openshift.com)


### PR DESCRIPTION
Heroku PHP support is now GA.
https://blog.heroku.com/archives/2014/7/15/the_new_php_on_heroku_now_generally_available
