### PR TITLE
Removed reference to maven

### DIFF
--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -53,7 +53,6 @@ Chef resources for PHP developers:
 Further reading:
 
 * [Automate your project with Apache Ant](http://net.tutsplus.com/tutorials/other/automate-your-projects-with-apache-ant/)
-* [Maven](http://maven.apache.org/), a build framework based on Ant and [how to use it with PHP](http://www.php-maven.org/)
 
 ### Continuous Integration
 


### PR DESCRIPTION
The php-maven.org project has not been maintained for the last couple of years.  It looked promising but doesn't work out of the box, and searching the web, I couldn't find anyone successfully getting it working recently.  It looks like a lost cause for php.
