### PR TITLE
Fix menu links for "welcome" anchors.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -35,8 +35,8 @@
                 <li><a href="/#site-header">Welcome</a>
                     <ul>
                         <li><a href="/#translations">Translations</a></li>
-                        <li><a href="/#how_to_contribute">How to Contribute</a></li>
-                        <li><a href="/#spread_the_word">Spread the Word!</a></li>
+                        <li><a href="/#how-to-contribute">How to Contribute</a></li>
+                        <li><a href="/#spread-the-word">Spread the Word!</a></li>
                     </ul>
                 </li>
                 {% assign lastIsChild = false %}


### PR DESCRIPTION
This fixes the broken "How to Contribute" and "Spread the Word" links in the menu.

In the `index.html`, `{{ welcome_content|markdownify }}` generates name
attributes for header tags like "my-title", whereas `{{ post.content }}`
generates name attributes like "my_title".

This fixes the links for only the welcome menu items so that the anchors
in the menu match the different name format.

I couldn't figure out how to change the name format, so at least this fixes the
links, even if it isn't consistent.
