### PR TITLE
Change branch names from "master" to "gh-pages".

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ included in the project:
 2. If you cloned a while ago, get the latest changes from upstream:
 
    ```bash
-   git checkout master
-   git pull upstream master
+   git checkout gh-pages
+   git pull upstream gh-pages
    ```
 
 3. Create a new topic branch (off the main project development branch) to
@@ -73,7 +73,7 @@ included in the project:
 6. Locally merge (or rebase) the upstream development branch into your topic branch:
 
    ```bash
-   git pull [--rebase] upstream master
+   git pull [--rebase] upstream gh-pages
    ```
 
 7. Push your topic branch up to your fork:


### PR DESCRIPTION
This updates the CONTRIBUTING.md instructions to reference the "gh-pages" branch instead of "master".
