### PR TITLE
Fixed inconsistent naming of example function

### DIFF
--- a/_posts/07-02-01-Interacting-via-Code.md
+++ b/_posts/07-02-01-Interacting-via-Code.md
@@ -26,11 +26,11 @@ Consider the most basic step:
 
 {% highlight php %}
 <?php
-function getAllSomethings($db) {
+function getAllFoos($db) {
     return $db->query('SELECT * FROM table');
 }
 
-foreach (getAllFoos() as $row) {
+foreach (getAllFoos($db) as $row) {
     echo "<li>".$row['field1']." - ".$row['field1']."</li>"; // BAD!!
 }
 {% endhighlight %}


### PR DESCRIPTION
I noticed inconsistent naming of an example function. 

So I suggest a change from this:

``` php
function getAllSomethings($db) {
    return $db->query('SELECT * FROM table');
}

foreach (getAllFoos() as $row) {
    echo "<li>".$row['field1']." - ".$row['field1']."</li>"; // BAD!!
}
```

...to this: 

``` php
function getAllFoos($db) {
    return $db->query('SELECT * FROM table');
}

foreach (getAllFoos($db) as $row) {
    echo "<li>".$row['field1']." - ".$row['field1']."</li>"; // BAD!!
}
```
