### PR TITLE
Add meta charset in head

### DIFF
--- a/_posts/05-05-01-PHP-and-UTF8.md
+++ b/_posts/05-05-01-PHP-and-UTF8.md
@@ -109,10 +109,11 @@ $handle->execute();
 // Store the result into an object that we'll output later in our HTML
 $result = $handle->fetchAll(\PDO::FETCH_OBJ);
 
-header('Content-Type: text/html; charset=utf-8');
+header('Content-Type: text/html; charset=UTF-8');
 ?><!doctype html>
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>UTF-8 test page</title>
     </head>
     <body>


### PR DESCRIPTION
The HTTP Content-Type header has precedence but adding a meta charset in the head helps when opening an offline (e.g. downloaded) file in the browser.

Also, note that the official character set name is in uppercase.
See: http://www.iana.org/assignments/character-sets/character-sets.xhtml
