### PR TITLE
Add chef video tutorial to Building-your-Application page.

### DIFF
--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -49,7 +49,7 @@ Chef resources for PHP developers:
 
 * [Three part blog series about deploying a LAMP application with Chef, Vagrant, and EC2](http://www.jasongrimes.org/2012/06/managing-lamp-environments-with-chef-vagrant-and-ec2-1-of-3/)
 * [Chef Cookbook which installs and configures PHP 5.3 and the PEAR package management system](https://github.com/opscode-cookbooks/php)
-
+* [Chef video tutorial series by Opscode, the makers of chef](https://www.youtube.com/playlist?list=PLrmstJpucjzWKt1eWLv88ZFY4R1jW8amR)
 Further reading:
 
 * [Automate your project with Apache Ant](http://net.tutsplus.com/tutorials/other/automate-your-projects-with-apache-ant/)


### PR DESCRIPTION
I looked here to see the recommended resources for learning chef (and the other various provisioning tools). After trying to use the blog linked here I found it did a lot of telling me "how to do this" in chef, but very little "why this works". 

Later on I found this video series which I found extremely helpful and comprehensive, especially for somebody who has never used automated server configuration software before. So I think this video series should definitely be included in this section.

There's also the main tutorial walkthrough by Opscode on their site, but the playlist references it and even follows it along in one of the videos so I don't think that also needs to be added to the links here.
