### PR TITLE
Order translations alphabetically

### DIFF
--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -21,23 +21,23 @@ and examples as they become available.
 _PHP: The Right Way_ is (or soon will be) translated into many different languages:
 
 * [English](http://www.phptherightway.com)
+* [Bulgarian](http://bg.phptherightway.com/)
 * [Chinese (Simplified)](http://wulijun.github.com/php-the-right-way)
 * [French](http://eilgin.github.io/php-the-right-way/)
-* [Japanese](http://ja.phptherightway.com)
-* [Korean](http://wafe.github.io/php-the-right-way/)
+* [German](http://rwetzlmayr.github.io/php-the-right-way/)
 * [Indonesian](http://id.phptherightway.com/)
 * [Italian](http://it.phptherightway.com/)
+* [Japanese](http://ja.phptherightway.com)
+* [Korean](http://wafe.github.io/php-the-right-way/)
 * [Polish](http://pl.phptherightway.com/)
 * [Portuguese](http://br.phptherightway.com/)
 * [Romanian](https://bgui.github.io/php-the-right-way/)
 * [Russian](http://getjump.github.io/ru-php-the-right-way)
+* [Slovenian](http://sl.phptherightway.com)
 * [Spanish](http://phpdevenezuela.github.io/php-the-right-way/)
-* [Ukrainian](http://iflista.github.com/php-the-right-way/)
-* [Bulgarian](http://bg.phptherightway.com/)
-* [German](http://rwetzlmayr.github.io/php-the-right-way/)
 * [Thai](https://apzentral.github.io/php-the-right-way/)
 * [Turkish](http://hkulekci.github.io/php-the-right-way/)
-* [Slovenian](http://sl.phptherightway.com)
+* [Ukrainian](http://iflista.github.com/php-the-right-way/)
 
 ## How to Contribute
 


### PR DESCRIPTION
It is easier to find translation if they are in alphabetical order. However, it's good to have English first, so it stays on the top.
