### PR TITLE
Close #450 - Reword 04 to use Composer as global package manager

### DIFF
--- a/_posts/04-01-01-Dependency-Management.md
+++ b/_posts/04-01-01-Dependency-Management.md
@@ -6,9 +6,4 @@ anchor: dependency_management
 
 There are a ton of PHP libraries, frameworks, and components to choose from. Your project will likely use several of them — these are project dependencies. Until recently, PHP did not have a good way to manage these project dependencies. Even if you managed them manually, you still had to worry about autoloaders. No more.
 
-Currently there are two major package management systems for PHP - Composer and PEAR. Which one is right for you? The answer is both.
-
- * Use **Composer** when managing dependencies for a single project.
- * Use **PEAR** when managing dependencies for PHP as a whole on your system.
-
-In general, Composer packages will be available only in the projects that you explicitly specify whereas a PEAR package would be available to all of your PHP projects. While PEAR might sound like the easier approach at first glance, there are advantages to using a project-by-project approach to your dependencies.
+Currently there are two major package management systems for PHP - Composer and PEAR. The former is the main package manager to use for PHP, however for a long time PEAR used to fill that role, and you may still find references to it so it's a good idea to be aware of its extistence too.

--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -40,7 +40,7 @@ The path `$HOME/local/bin` (or a directory of your choice) should be in your `$P
 When you come across documentation that states to run Composer as `php composer.phar install`, you can substitute that with:
 
     composer install
-    
+
 This section will assume you have installed composer globally.
 
 ### How to Define and Install Dependencies
@@ -70,7 +70,7 @@ This is most useful when you define your version requirements flexibly. For inst
 
 ### Update Notifications
 
-To receive notifications about new version releases you can sign up for [VersionEye][3], a web service that can monitor 
+To receive notifications about new version releases you can sign up for [VersionEye][3], a web service that can monitor
 your GitHub and BitBucket accounts for `composer.json` files and send emails with new package releases.
 
 ### Checking your dependencies for security issues
@@ -86,3 +86,10 @@ The [Security Advisories Checker][4] is a web service and a command-line tool, b
 [5]: http://getcomposer.org/doc/00-intro.md
 [6]: https://getcomposer.org/Composer-Setup.exe
 
+### Handling global dependencies with Composer
+
+Composer can also handle global dependencies and their binaries. Usage is straight-forward, all you need to do is prefix your command with `global`. If per example you wanted to install PHPUnit and have it available globally, you'd run the following command:
+
+    composer global require phpunit/phpunit
+
+This will create a `~/.composer` folder where your global dependencies reside. To have the installed packages' binaries available everywhere, you'd then add the `~/.composer/vendor/bin` folder to your PATH.


### PR DESCRIPTION
I'm really not sure about the wording or if the section is enough to explain it so, input more than welcome. I was also not sure about whether to remove or not the PEAR section, so, input on that too.

On a separate note, I wasn't sure whether to put the version constraint in the example considering Composer now defaults to the latest stable version if you don't put it, which might be better practice, but the above example with Twig had it so.
