### PR TITLE
Used .html as filename extension for templates

### DIFF
--- a/_posts/08-04-01-Compiled-Templates.md
+++ b/_posts/08-04-01-Compiled-Templates.md
@@ -37,7 +37,7 @@ Using the [Twig](http://twig.sensiolabs.org/) library.
 
 {% highlight text %}
 {% raw %}
-// template.php
+// template.html
 
 <html>
 <head>
@@ -56,7 +56,7 @@ Using the [Twig](http://twig.sensiolabs.org/) library.
 
 {% highlight text %}
 {% raw %}
-// user_profile.php
+// user_profile.html
 
 {% extends "template.html" %}
 


### PR DESCRIPTION
In `user_profile` we're actually extending `template.html` and not `template.php`.
