### PR TITLE
Link to @auraphp website v2 packages

### DIFF
--- a/_posts/15-03-01-Components.md
+++ b/_posts/15-03-01-Components.md
@@ -23,7 +23,7 @@ itself.
   [Dependency Management]: /#dependency_management
   [FuelPHP Validation package]: https://github.com/fuelphp/validation
 
-* [Aura](http://auraphp.github.com/)
+* [Aura](http://auraphp.com/packages/v2)
 * [FuelPHP](https://github.com/fuelphp)
 * [Hoa Project](https://github.com/hoaproject)
 * [Orno](https://github.com/orno)


### PR DESCRIPTION
Linking to auraphp.com rather than auraphp.github.com .

@pmjones do you have a different opinion on this ?

Thank you.
