### PR TITLE
Pygments option deprecated, using highlighter option instead

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ safe: true
 baseurl: /
 url: http://localhost:4000
 
-pygments: true
+highlighter: pygments
 markdown: kramdown
 permalink: date
 maruku:


### PR DESCRIPTION
Option pygments is deprecated, commit https://github.com/jekyll/jekyll/commit/92064134d67eb17392a45e4fc82d83423a4b8ff4
