### PR TITLE
Fix highlighter consistency

### DIFF
--- a/_posts/01-03-01-Built-in-Web-Server.md
+++ b/_posts/01-03-01-Built-in-Web-Server.md
@@ -8,7 +8,9 @@ anchor: builtin_web_server
 
 With PHP 5.4 or newer, you can start learning PHP without installing and configuring a full-fledged web server. To start the server, run the following command from your terminal in your project's web root:
 
-    > php -S localhost:8000
+{% highlight console %}
+> php -S localhost:8000
+{% endhighlight %}
 
 * [Learn about the built-in, command line web server][cli-server]
 

--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -11,7 +11,7 @@ CLI PHP programs are powerful because you can use your app's code directly witho
 
 Try running PHP from your command line:
 
-{% highlight bash %}
+{% highlight console %}
 > php -i
 {% endhighlight %}
 
@@ -37,7 +37,7 @@ The `exit()` expression is used with a non-zero number to let the shell know tha
 
 To run our script, above, from the command line:
 
-{% highlight bash %}
+{% highlight console %}
 > php hello.php
 Usage: php hello.php [name]
 > php hello.php world

--- a/_posts/03-06-01-XDebug.md
+++ b/_posts/03-06-01-XDebug.md
@@ -20,8 +20,10 @@ want to enable right away.
 
 Traditionally, you will modify your Apache VHost or .htaccess file with these values:
 
-    php_value xdebug.remote_host=192.168.?.?
-    php_value xdebug.remote_port=9000
+{% highlight ini %}
+php_value xdebug.remote_host=192.168.?.?
+php_value xdebug.remote_port=9000
+{% endhighlight %}
 
 The "remote host" and "remote port" will correspond to your local computer and the port that you configure your IDE to
 listen on. Then it's just a matter of putting your IDE into "listen for connections" mode, and loading the URL:

--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -13,7 +13,9 @@ There are already a lot of PHP libraries that are compatible with Composer, read
 
 You can install Composer locally (in your current working directory; though this is no longer recommended) or globally (e.g. /usr/local/bin). Let's assume you want to install Composer locally. From your project's root directory:
 
-    curl -s https://getcomposer.org/installer | php
+{% highlight console %}
+curl -s https://getcomposer.org/installer | php
+{% endhighlight %}
 
 This will download `composer.phar` (a PHP binary archive). You can run this with `php` to manage your project dependencies. <strong>Please Note:</strong> If you pipe downloaded code directly into an interpreter, please read the code online first to confirm it is safe.
 
@@ -32,26 +34,34 @@ Manually installing Composer is an advanced technique; however, there are variou
 
 Since a manual installation performs none of these checks, you have to decide whether the trade-off is worth it for you. As such, below is how to obtain Composer manually:
 
-    curl -s https://getcomposer.org/composer.phar -o $HOME/local/bin/composer
-    chmod +x $HOME/local/bin/composer
+{% highlight console %}
+curl -s https://getcomposer.org/composer.phar -o $HOME/local/bin/composer
+chmod +x $HOME/local/bin/composer
+{% endhighlight %}
 
 The path `$HOME/local/bin` (or a directory of your choice) should be in your `$PATH` environment variable. This will result in a `composer` command being available.
 
 When you come across documentation that states to run Composer as `php composer.phar install`, you can substitute that with:
 
-    composer install
-    
+{% highlight console %}
+composer install
+{% endhighlight %}
+
 This section will assume you have installed composer globally.
 
 ### How to Define and Install Dependencies
 
 Composer keeps track of your project's dependencies in a file called `composer.json`. You can manage it by hand if you like, or use Composer itself. The `composer require` command adds a project dependency and if you don't have a `composer.json` file, one will be created. Here's an example that adds [Twig][2] as a dependency of your project.
 
-	composer require twig/twig:~1.8
+{% highlight console %}
+composer require twig/twig:~1.8
+{% endhighlight %}
 
 Alternatively the `composer init` command will guide you through creating a full `composer.json` file for your project. Either way, once you've created your `composer.json` file you can tell Composer to download and install your dependencies into the `vendor/` directory. This also applies to projects you've downloaded that already provide a `composer.json` file:
 
-    composer install
+{% highlight console %}
+composer install
+{% endhighlight %}
 
 Next, add this line to your application's primary PHP file; this will tell PHP to use Composer's autoloader for your project dependencies.
 

--- a/_posts/04-03-01-PEAR.md
+++ b/_posts/04-03-01-PEAR.md
@@ -27,8 +27,10 @@ have an apt ``php-pear`` package.
 
 If the package is listed on the [PEAR packages list][3], you can install it by specifying the official name:
 
+{% highlight console %}
     pear install foo
-    
+{% endhighlight %}
+
 If the package is hosted on another channel, you need to `discover` the channel first and also specify it when 
 installing. See the [Using channel docs][4] for more information on this topic.
 
@@ -71,6 +73,7 @@ available through the Composer autoloader:
 To use this PEAR package simply reference it like so:
 
 {% highlight php %}
+<?php
 $request = new pear2\HTTP\Request();
 {% endhighlight %}
 

--- a/_posts/07-02-01-Interacting-via-Code.md
+++ b/_posts/07-02-01-Interacting-via-Code.md
@@ -44,7 +44,6 @@ Create a class to place that method in and you have a "Model". Create a simple `
 
 {% highlight php %}
 <?php
-
 $db = new PDO('mysql:host=localhost;dbname=testdb;charset=utf8', 'username', 'password');
 
 // Make your model available

--- a/_posts/09-02-01-Errors.md
+++ b/_posts/09-02-01-Errors.md
@@ -12,7 +12,7 @@ processing regardless of what happens, unless a fatal error occurs.
 
 For example:
 
-{% highlight php %}
+{% highlight console %}
 $ php -a
 php > echo $foo;
 Notice: Undefined variable: foo in php shell code on line 1
@@ -21,7 +21,7 @@ Notice: Undefined variable: foo in php shell code on line 1
 This is only a notice error, and PHP will happily carry on. This can be confusing for those coming from "exception-heavy" 
 languages, because referencing a missing variable in Python for example will throw an exception:
 
-{% highlight python %}
+{% highlight console %}
 $ python
 >>> print foo
 Traceback (most recent call last):
@@ -50,6 +50,7 @@ predefined error level constants, meaning if you only want to see Warnings and E
 you can configure that:
 
 {% highlight php %}
+<?php
 error_reporting(E_ERROR | E_WARNING);
 {% endhighlight %}
 
@@ -62,6 +63,7 @@ You can also tell PHP to suppress specific errors with the Error Control Operato
 this operator at the beginning of an expression, and any error that's a direct result of the expression is silenced. 
 
 {% highlight php %}
+<?php
 echo @$foo['bar'];
 {% endhighlight %}
 
@@ -75,6 +77,7 @@ Secondly, the error control operator **completely** swallows the error.  The err
 If there's a way to avoid the error suppression operator, you should consider it.  For example, our code above could be rewritten like this
 
 {% highlight php %}
+<?php
 echo isset($foo['bar']) ? $foo['bar'] : '';
 {% endhighlight %}
 
@@ -86,11 +89,14 @@ solution.
 
 Earlier we mentioned there's no way in a stock PHP system to turn off the error control operator.  However, [xDebug] has an `xdebug.scream` ini setting which will disable the error control operator.  You can set this via your `php.ini` file with the following.
 
-    xdebug.scream = On
+{% highlight ini %}
+xdebug.scream = On
+{% endhighlight %}
     
 You can also set this value at runtime with the `ini_set` function 
 
 {% highlight php %}
+<?php
 ini_set('xdebug.scream', '1')
 {% endhighlight %}
 

--- a/_posts/10-03-01-Password-Hashing.md
+++ b/_posts/10-03-01-Password-Hashing.md
@@ -17,7 +17,6 @@ Below we hash a string, and then check the hash against a new string. Because ou
 
 {% highlight php %}
 <?php
-                      
 require 'password.php';
 
 $passwordHash = password_hash('secret-password', PASSWORD_DEFAULT);

--- a/_posts/10-07-01-Error-Reporting.md
+++ b/_posts/10-07-01-Error-Reporting.md
@@ -7,17 +7,19 @@ anchor: error_reporting
 
 Error logging can be useful in finding the problem spots in your application, but it can also expose information about 
 the structure of your application to the outside world. To effectively protect your application from issues that could 
-be caused by the output of these messages, you need to configure your server differently in development versus 
+be caused by the output of these messages, you need to configure your server differently in development versus
 production (live).
 
 ### Development
 
 To show every possible error during <strong>development</strong>, configure the following settings in your `php.ini`:
 
-    display_errors = On
-    display_startup_errors = On
-    error_reporting = -1
-    log_errors = On
+{% highlight ini %}
+display_errors = On
+display_startup_errors = On
+error_reporting = -1
+log_errors = On
+{% endhighlight %}
 
 > Passing in the value `-1` will show every possible error, even when new levels and constants are added in future PHP versions. The `E_ALL` constant also behaves this way as of PHP 5.4. - [php.net](http://php.net/function.error-reporting)
 
@@ -36,10 +38,12 @@ use either `-1` or `E_ALL | E_STRICT`.
 
 To hide errors on your <strong>production</strong> environment, configure your `php.ini` as:
 
-    display_errors = Off
-    display_startup_errors = Off
-    error_reporting = E_ALL
-    log_errors = On
+{% highlight ini %}
+display_errors = Off
+display_startup_errors = Off
+error_reporting = E_ALL
+log_errors = On
+{% endhighlight %}
 
 With these settings in production, errors will still be logged to the error logs for the web server, but will not be 
 shown to the user. For more information on these settings, see the PHP manual:

--- a/_posts/13-03-01-Docker.md
+++ b/_posts/13-03-01-Docker.md
@@ -17,7 +17,7 @@ After you [installed docker][docker-install] on your machine, you can start an A
 The following command will download a fully functional Apache installation with the latest PHP version and provide the
 directory `/path/to/your/php/files` at `http://localhost:8080`:
 
-{% highlight bash %}
+{% highlight console %}
 docker run -d --name my-php-webserver -p 8080:80 -v /path/to/your/php/files:/var/www/html/ php:apache 
 {% endhighlight %}
 

--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -203,7 +203,6 @@ The next snippet of code outlines how a calling client class might use one of th
 behaviour required at runtime:
 {% highlight php %}
 <?php
-
 class SomeClient
 {
     private $output;
@@ -225,7 +224,6 @@ once this property is set a call to loadOutput() will call the load() method in 
 that has been set.
 {% highlight php %}
 <?php
-
 $client = new SomeClient();
 
 // Want an array?

--- a/pages/The-Basics.md
+++ b/pages/The-Basics.md
@@ -361,7 +361,6 @@ return ($a == 3) ? "yay" : "nope"; // return yay or nope if $a == 3
 
 // vs
 
-<?php
 $a = 3;
 return $a == 3 ? "yay" : "nope"; // return yay or nope if $a == 3
 {% endhighlight %}


### PR DESCRIPTION
- in some places php would not be highlighted as the `<?php` tag was missing
- in one place there was a duplicate `<?php` tag
- replaced `bash` with `console` for slightly better highlighting
- ensured all console snippets are wrapped within highlighting code
- wrapped `ini` examples in highlighting code

Boyscouting ;-) some more PRs like this coming up.
