### PR TITLE
Use static property instead of static variable

### DIFF
--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -73,7 +73,7 @@ one instance of a particular class. The singleton pattern enables us to do this.
 class Singleton
 {
     /**
-     * @static Singleton The reference to *Singleton* instance of this class
+     * @var Singleton The reference to *Singleton* instance of this class
      */
     private static $instance;
     

--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -73,20 +73,22 @@ one instance of a particular class. The singleton pattern enables us to do this.
 class Singleton
 {
     /**
+     * @static Singleton The reference to *Singleton* instance of this class
+     */
+    private static $instance;
+    
+    /**
      * Returns the *Singleton* instance of this class.
-     *
-     * @staticvar Singleton $instance The *Singleton* instances of this class.
      *
      * @return Singleton The *Singleton* instance.
      */
     public static function getInstance()
     {
-        static $instance = null;
-        if (null === $instance) {
-            $instance = new static();
+        if (null === static::$instance) {
+            static::$instance = new static();
         }
-
-        return $instance;
+        
+        return static::$instance;
     }
 
     /**


### PR DESCRIPTION
I think better to use OOP static property for Singleton class like in other resources, isn't it?
- [domnikl/DesignPatternsPHP Singleton](https://github.com/domnikl/DesignPatternsPHP/blob/master/Creational/Singleton/Singleton.php#L13)
- [Singleton Wiki](https://uk.wikipedia.org/wiki/%D0%9E%D0%B4%D0%B8%D0%BD%D0%B0%D0%BA_%28%D1%88%D0%B0%D0%B1%D0%BB%D0%BE%D0%BD_%D0%BF%D1%80%D0%BE%D0%B5%D0%BA%D1%82%D1%83%D0%B2%D0%B0%D0%BD%D0%BD%D1%8F%29#.D0.A0.D0.B5.D0.B0.D0.BB.D1.96.D0.B7.D0.B0.D1.86.D1.96.D1.8F_.D0.BD.D0.B0_PHP5)
