### PR TITLE
Adding official PUG-listing at php.net/ug.php

### DIFF
--- a/_posts/17-02-01-User-Groups.md
+++ b/_posts/17-02-01-User-Groups.md
@@ -5,9 +5,10 @@ anchor:  user_groups
 
 ## PHP User Groups {#user_groups_title}
 
-If you live in a larger city, odds are there's a PHP user group nearby. Although there's not yet an official list of
-PUGs, you can easily find your local PUG by searching on [Google][google], [Meetup.com][meetup] or [PHP.ug][php-ug]. If
-you live in a smaller town, there may not be a local PUG; if that's the case, start one!
+If you live in a larger city, odds are there's a PHP user group nearby. You can easily find your local PUG at
+the [usergroup-list at php.net][php-uglist] which is based upon [PHP.ug][php-ug]. Alternate sources might be
+[Meetup.com][meetup] or a search for ```php user group near me``` using your favourite search engine
+(i.e. [Google][google]). If you live in a smaller town, there may not be a local PUG; if that's the case, start one!
 
 Special mention should be made of two global user groups: [NomadPHP] and [PHPWomen]. [NomadPHP] offers twice monthly
 online user group meetings with presentations by some of the top speakers in the PHP community.
@@ -23,3 +24,4 @@ generally promote the creating of a "female friendly" and professional atmospher
 [NomadPHP]: https://nomadphp.com/
 [PHPWomen]: http://phpwomen.org/
 [php-wiki]: https://wiki.php.net/usergroups
+[php-uglist]: http://php.net/ug.php


### PR DESCRIPTION
This PR adds a link to the official usergroup-list at php.net.

Being a list on php.net I thought it's the "official" list of php usergroups. Therefore I've changed the wording slightly. 
