### PR TITLE
No-escape underscores in MySQL table/column identifiers

### DIFF
--- a/_posts/07-03-01-Databases_PDO.md
+++ b/_posts/07-03-01-Databases_PDO.md
@@ -14,13 +14,13 @@ MySQL or SQLite:
 <?php
 // PDO + MySQL
 $pdo = new PDO('mysql:host=example.com;dbname=database', 'user', 'password');
-$statement = $pdo->query("SELECT some\_field FROM some\_table");
+$statement = $pdo->query("SELECT some_field FROM some_table");
 $row = $statement->fetch(PDO::FETCH_ASSOC);
 echo htmlentities($row['some_field']);
 
 // PDO + SQLite
 $pdo = new PDO('sqlite:/path/db/foo.sqlite');
-$statement = $pdo->query("SELECT some\_field FROM some\_table");
+$statement = $pdo->query("SELECT some_field FROM some_table");
 $row = $statement->fetch(PDO::FETCH_ASSOC);
 echo htmlentities($row['some_field']);
 {% endhighlight %}


### PR DESCRIPTION
Underscore characters `_` in table/column/database identifiers should not be backslash-escaped, as they're in the character class MySQL & SQLite allow for unquoted identifiers, and would not be treated as wildcards in a `SELECT` statement like they would in a `GRANT` statement.

http://dev.mysql.com/doc/refman/5.0/en/identifiers.html
