### PR TITLE
Typos fixed

### DIFF
--- a/_posts/03-06-01-XDebug.md
+++ b/_posts/03-06-01-XDebug.md
@@ -1,20 +1,20 @@
 ---
-title:   XDebug
+title:   Xdebug
 isChild: true
 anchor:  xdebug
 ---
 
-## XDebug {#xdebug_title}
+## Xdebug {#xdebug_title}
 
 One of the most useful tools in software development is a proper debugger. It allows you to trace the execution of your
-code and monitor the contents of the stack. XDebug, PHP's debugger, can be utilized by various IDEs to provide
+code and monitor the contents of the stack. Xdebug, PHP's debugger, can be utilized by various IDEs to provide
 Breakpoints and stack inspection. It can also allow tools like PHPUnit and KCacheGrind to perform code coverage
 analysis and code profiling.
 
 If you find yourself in a bind, willing to resort to `var_dump()`/`print_r()`, and you still can't find the solution -
 maybe you need to use the debugger.
 
-[Installing XDebug][xdebug-install] can be tricky, but one of its most important features is "Remote Debugging" - if
+[Installing Xdebug][xdebug-install] can be tricky, but one of its most important features is "Remote Debugging" - if
 you develop code locally and then test it inside a VM or on another server, Remote Debugging is the feature that you
 will want to enable right away.
 
@@ -34,10 +34,10 @@ Your IDE will now intercept the current state as the script executes, allowing y
 values in memory.
 
 Graphical debuggers make it very easy to step through code, inspect variables, and eval code against the live runtime.
-Many IDE's have built-in or plugin-based support for graphical debugging with xdebug. MacGDBp is a free, open-source,
-stand-alone xdebug GUI for Mac.
+Many IDE's have built-in or plugin-based support for graphical debugging with Xdebug. MacGDBp is a free, open-source,
+stand-alone Xdebug GUI for Mac.
 
- * [Learn more about XDebug][xdebug-docs]
+ * [Learn more about Xdebug][xdebug-docs]
  * [Learn more about MacGDBp][macgdbp-install]
 
 

--- a/_posts/09-02-01-Errors.md
+++ b/_posts/09-02-01-Errors.md
@@ -5,8 +5,8 @@ anchor:  errors
 
 ## Errors {#errors_title}
 
-In many "exception-heavy" programming languages, whenever anything goes wrong an exception will be thrown. This is 
-certainly a viable way to do things, but PHP is an "exception-light" programming language. While it does have 
+In many "exception-heavy" programming languages, whenever anything goes wrong an exception will be thrown. This is
+certainly a viable way to do things, but PHP is an "exception-light" programming language. While it does have
 exceptions and more of the core is starting to use them when working with objects, most of PHP itself will try to keep
 processing regardless of what happens, unless a fatal error occurs.
 
@@ -96,14 +96,14 @@ for the existence of the file before you try to load it, but if the file is dele
 is potentially something PHP should resolve, but is one case where error suppression might seem like the only valid
 solution.
 
-Earlier we mentioned there's no way in a stock PHP system to turn off the error control operator. However, [xDebug] has
+Earlier we mentioned there's no way in a stock PHP system to turn off the error control operator. However, [Xdebug] has
 an `xdebug.scream` ini setting which will disable the error control operator. You can set this via your `php.ini` file
 with the following.
 
 {% highlight ini %}
 xdebug.scream = On
 {% endhighlight %}
-    
+
 You can also set this value at runtime with the `ini_set` function 
 
 {% highlight php %}
@@ -111,7 +111,7 @@ You can also set this value at runtime with the `ini_set` function
 ini_set('xdebug.scream', '1')
 {% endhighlight %}
 
-The "[Scream]" PHP extension offers similar functionality to xDebug's, although Scream's ini setting is named
+The "[Scream]" PHP extension offers similar functionality to Xdebug's, although Scream's ini setting is named
 `scream.enabled`.
 
 This is most useful when you're debugging code and suspect an informative error is suppressed. Use scream with care,
@@ -121,7 +121,7 @@ disabled.
 
 * [Error Control Operators]
 * [SitePoint]
-* [xDebug] 
+* [Xdebug]
 * [Scream]
 
 
@@ -149,7 +149,7 @@ More information on this and details on how to use `ErrorException` with error h
 
 
 [errorreport]: /#error_reporting
-[xDebug]: http://xdebug.org/docs/basic
+[Xdebug]: http://xdebug.org/docs/basic
 [Scream]: http://php.net/book.scream
 [Error Control Operators]: http://php.net/language.operators.errorcontrol
 [SitePoint]: http://www.sitepoint.com/

--- a/_posts/13-02-01-Vagrant.md
+++ b/_posts/13-02-01-Vagrant.md
@@ -19,13 +19,13 @@ create and edit your files on your host machine and then run the code inside you
 
 If you need a little help to start using Vagrant there are some services that might be useful:
 
-- [Rove]: service that allows you to pre-generate typical Vagrant builds, PHP among the options. The provisioning is
+- [Rove][Rove]: service that allows you to pre-generate typical Vagrant builds, PHP among the options. The provisioning is
 made with Chef.
-- [Puphpet]: simple GUI to set up virtual machines for PHP development. **Heavily focused in PHP**. Besides local VMs,
+- [Puphpet][Puphpet]: simple GUI to set up virtual machines for PHP development. **Heavily focused in PHP**. Besides local VMs,
 it can be used to deploy to cloud services as well. The provisioning is made with Puppet.
-- [ Protobox]: is a layer on top of vagrant and a web GUI to setup virtual machines for web development. A single YAML
+- [Protobox][Protobox]: is a layer on top of vagrant and a web GUI to setup virtual machines for web development. A single YAML
 document controls everything that is installed on the virtual machine.
-- [Phansible]: provides an easy to use interface that helps you generate Ansible Playbooks for PHP based projects.
+- [Phansible][Phansible]: provides an easy to use interface that helps you generate Ansible Playbooks for PHP based projects.
 
 
 [Vagrant]: http://vagrantup.com/


### PR DESCRIPTION
Some minor typos fixed: 
- links in Vagrant sections now works
- Xdebug spelled more properly according to the xdebug.org website
