### PR TITLE
Unneeded config options removed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,3 @@
-baseurl: /
-url: http://localhost:4000
-
 highlighter: pygments
 markdown: kramdown
 permalink: date


### PR DESCRIPTION
When generating the sitemap.xml file the localhost:4000 url is inserted on GitHub pages. This patch removed unneeded options for sitemap:
http://www.phptherightway.com/sitemap.xml
