### PR TITLE
Fix comment error around UTF-8 and PDO

### DIFF
--- a/_posts/05-05-01-PHP-and-UTF8.md
+++ b/_posts/05-05-01-PHP-and-UTF8.md
@@ -86,7 +86,7 @@ $string = mb_substr($string, 0, 15);
  
 // Connect to a database to store the transformed string
 // See the PDO example in this document for more information
-// Note the `set names utf8mb4` commmand!
+// Note the `charset=utf8mb4` in the Data Source Name (DSN)
 $link = new PDO(
     'mysql:host=your-hostname;dbname=your-db;charset=utf8mb4',
     'your-username',

--- a/_posts/07-03-01-Databases_PDO.md
+++ b/_posts/07-03-01-Databases_PDO.md
@@ -50,12 +50,15 @@ FROM users` which will delete all of your users! Instead, you should sanitize th
 <?php
 $pdo = new PDO('sqlite:/path/db/users.db');
 $stmt = $pdo->prepare('SELECT name FROM users WHERE id = :id');
-$stmt->bindParam(':id', $_GET['id'], PDO::PARAM_INT); // <-- Automatically sanitized by PDO
+$id = filter_input(FILTER_GET, 'id', FILTER_SANITIZE_NUMBER_INT); // <-- filter your data first (see [Data Filtering](#data_filtering)), especially important for INSERT, UPDATE, etc.
+$stmt->bindParam(':id', $id, PDO::PARAM_INT); // <-- Automatically sanitized for SQL by PDO
 $stmt->execute();
 {% endhighlight %}
 
 This is correct code. It uses a bound parameter on a PDO statement. This escapes the foreign input ID before it is
 introduced to the database preventing potential SQL injection attacks.
+
+For writes, such as INSERT or UPDATE, it's especially critical to still [filter your data](#data_filtering) first and sanitize it for other things (removal of HTML tags, JavaScript, etc).  PDO will only sanitize it for SQL, not for your application.
 
 * [Learn about PDO]
 


### PR DESCRIPTION
Looks like at some point the UTF-8 example rightfully moved from using 'set names' to including the charset in the DSN, but one of the comments didn't keep up.
