### PR TITLE
Adding baseurl back to config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+baseurl: /
 highlighter: pygments
 markdown: kramdown
 permalink: date


### PR DESCRIPTION
Here is one more patch for Jekyll configuration. Configuration parameter baseurl is needed afterall as noticed in #519 
