### PR TITLE
Use strict equality comparison when comparing ints

### DIFF
--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -26,7 +26,7 @@ Let's write a simple "Hello, $name" CLI program. To try it out, create a file na
 
 {% highlight php %}
 <?php
-if ($argc != 2) {
+if ($argc !== 2) {
     echo "Usage: php hello.php [name].\n";
     exit(1);
 }


### PR DESCRIPTION
This isn't a bug, per se, but being strict is "the right way" and important to get right in a code example here.
