### PR TITLE
use relative url for pages under `pages`

### DIFF
--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -31,7 +31,7 @@ New anonymous functions (with support for closures) are present since PHP 5.3 (2
 PHP 5.4 added the ability to bind closures to an object's scope and also improved support for callables such that they
 can be used interchangeably with anonymous functions in almost all cases.
 
-* Continue reading on [Functional Programming in PHP](/pages/Functional-Programming.html)
+* Continue reading on [Functional Programming in PHP](pages/Functional-Programming.html)
 * [Read about Anonymous Functions][anonymous-functions]
 * [Read about the Closure class][closure-class]
 * [More details in the Closures RFC][closures-rfc]

--- a/_posts/05-02-01-The-Basics.md
+++ b/_posts/05-02-01-The-Basics.md
@@ -10,4 +10,4 @@ However while advancing through the language, we often forget the basics that we
 of short cuts and/or bad habits. To help combat this common issue, this section is aimed at reminding coders of the
 basic coding practices within PHP.
 
-* Continue reading on [The Basics](/pages/The-Basics.html)
+* Continue reading on [The Basics](pages/The-Basics.html)

--- a/_posts/05-04-01-Design-Patterns.md
+++ b/_posts/05-04-01-Design-Patterns.md
@@ -14,4 +14,4 @@ lot of the pattern decisions are made for you. But it is still up to you to pick
 code you build on top of the framework. If, on the other hand, you are not using a framework to build your application
 then you have to find the patterns that best suit the type and size of application that you're building.
 
-* Continue reading on [Design Patterns](/pages/Design-Patterns.html)
+* Continue reading on [Design Patterns](pages/Design-Patterns.html)

--- a/_posts/08-01-01-Templating.md
+++ b/_posts/08-01-01-Templating.md
@@ -8,4 +8,4 @@ anchor: templating
 Templates provide a convenient way of separating your controller and domain logic from your presentation logic.
 Templates typically contain the HTML of your application, but may also be used for other formats, such as XML.
 Templates are often referred to as "views", which make up **part of** the second component of the
-[model–view–controller](/pages/Design-Patterns.html#model-view-controller) (MVC) software architecture pattern.
+[model–view–controller](pages/Design-Patterns.html#model-view-controller) (MVC) software architecture pattern.


### PR DESCRIPTION
Not all the forked versions put this book under root, relative url will be better,

or they'll got 404 error.
