### PR TITLE
Updated phpdoc stuff

### DIFF
--- a/_posts/15-02-01-PHPDoc.md
+++ b/_posts/15-02-01-PHPDoc.md
@@ -16,15 +16,15 @@ Below is an example of how you might document a class with a few methods;
 /**
  * @author A Name <a.name@example.com>
  * @link http://www.phpdoc.org/docs/latest/index.html
- * @package helper
  */
 class DateTimeHelper
 {
     /**
      * @param mixed $anything Anything that we can convert to a \DateTime object
      *
-     * @return \DateTime
      * @throws \InvalidArgumentException
+     *
+     * @return \DateTime
      */
     public function dateTimeFromAnything($anything)
     {
@@ -59,10 +59,9 @@ class DateTimeHelper
 }
 {% endhighlight %}
 
-The documentation for the class as a whole firstly has the [@author] tag, this tag is used to document the author of
-the code and can be repeated for documenting several authors. Secondly is the [@link] tag, used to link to a website
-indicating a relationship between the website and the code. Thirdly it has the [@package] tag, used to categorize the
-code.
+The documentation for the class as a whole has the [@author] tag and a [@link] tag. The [@author] tag is used to
+document the author of the code and can be repeated for documenting several authors. The [@link] tag is used to link to
+a website indicating a relationship between the website and the code.
 
 Inside the class, the first method has an [@param] tag documenting the type, name and description of the parameter
 being passed to the method. Additionally it has the [@return] and [@throws] tags for documenting the return type, and
@@ -78,7 +77,6 @@ results in the same (no return) action.
 [PHPDoc manual]: http://www.phpdoc.org/docs/latest/index.html
 [@author]: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/author.html
 [@link]: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/link.html
-[@package]: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/package.html
 [@param]: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/param.html
 [@return]: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/return.html
 [@throws]: http://www.phpdoc.org/docs/latest/references/phpdoc/tags/throws.html


### PR DESCRIPTION
I've updated the throws/returns order and separation to match the style inferred by the examples in the proposed psr docblock standard.

I've also removed the package annotation because I don't consider it meaningful and thus shouldn't be recommended in my opinion. Namespaces describe the package something belongs to well enough. :)

---

Replaces https://github.com/philsturgeon/phptherightway-book/pull/3.
