### PR TITLE
Add DOMDocument UTF-8 stackoverflow link.

### DIFF
--- a/_posts/05-05-01-PHP-and-UTF8.md
+++ b/_posts/05-05-01-PHP-and-UTF8.md
@@ -150,3 +150,4 @@ header('Content-Type: text/html; charset=UTF-8');
 * [Stack Overflow: Best practices in PHP and MySQL with international strings](http://stackoverflow.com/questions/140728/best-practices-in-php-and-mysql-with-international-strings)
 * [How to support full Unicode in MySQL databases](http://mathiasbynens.be/notes/mysql-utf8mb4)
 * [Bringing Unicode to PHP with Portable UTF-8](http://www.sitepoint.com/bringing-unicode-to-php-with-portable-utf8/)
+* [Stack Overflow: DOMDocument loadHTML does not encode UTF-8 correctly](http://stackoverflow.com/questions/8218230/php-domdocument-loadhtml-not-encoding-utf-8-correctly)


### PR DESCRIPTION
DOMDocument treats UTF-8 input like ISO 8859-1 and turns any non-ascii characters into separate, incorrect character entities, unless you use one of the workarounds described on this stackoverflow page.
