### PR TITLE
Add links to Brainy on the Compiled Templates page

### DIFF
--- a/_posts/08-04-01-Compiled-Templates.md
+++ b/_posts/08-04-01-Compiled-Templates.md
@@ -6,7 +6,7 @@ anchor:  compiled_templates
 ## Compiled Templates {#compiled_templates_title}
 
 While PHP has evolved into a mature, object oriented language, it [hasn't improved much][article_templating_engines] as
-a templating language. Compiled templates, like [Twig] or [Smarty]*, fill this void by offering a new syntax that has
+a templating language. Compiled templates, like [Twig], [Brainy], or [Smarty]*, fill this void by offering a new syntax that has
 been geared specifically to templating. From automatic escaping, to inheritance and simplified control structures,
 compiled templates are designed to be easier to write, cleaner to read and safer to use. Compiled templates can even be
 shared across different languages, [Mustache] being a good example of this. Since these templates must be compiled
@@ -69,5 +69,6 @@ Using the [Twig] library.
 
 [article_templating_engines]: http://fabien.potencier.org/article/34/templating-engines-in-php
 [Twig]: http://twig.sensiolabs.org/
+[Brainy]: https://github.com/box/brainy
 [Smarty]: http://www.smarty.net/
 [Mustache]: http://mustache.github.io/

--- a/_posts/08-05-01-Further-Reading.md
+++ b/_posts/08-05-01-Further-Reading.md
@@ -13,11 +13,13 @@ anchor:  templating_further_reading
 * [Roll Your Own Templating System in PHP](http://code.tutsplus.com/tutorials/roll-your-own-templating-system-in-php--net-16596)
 * [Master Pages](https://laracasts.com/series/laravel-from-scratch/episodes/7)
 * [Working With Templates in Symfony 2](http://code.tutsplus.com/tutorials/working-with-templates-in-symfony-2--cms-21172)
+* [Writing Safer Templates](https://github.com/box/brainy/wiki/Writing-Safe-Templates)
 
 ### Libraries
 
 * [Aura.View](https://github.com/auraphp/Aura.View) *(native)*
 * [Blade](http://laravel.com/docs/templates) *(compiled, framework specific)*
+* [Brainy](https://github.com/box/brainy) *(compiled)*
 * [Dwoo](http://dwoo.org/) *(compiled)*
 * [Latte](https://github.com/nette/latte) *(compiled)*
 * [Mustache](https://github.com/bobthecow/mustache.php) *(compiled)*


### PR DESCRIPTION
Brainy is a fork of Smarty that is focused on enhancing Smarty's
security and performance. By default, it includes safer security
defaults while also bundling features that make it less susceptible to
XSS and other types of attacks.

---

Hi all, I'm hoping to add [Brainy](https://github.com/box/brainy) to the page on compiled templates. We've been working hard on it at Box and are hoping to include it in PTRW. Please let me know what you think, and whether there's anything I could do to improve this PR.

Thanks!
