### PR TITLE
Remove the ajax GH API call in favour of using GitHub metadata in Jekyll

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -89,7 +89,17 @@
                         <li><a href="http://philsturgeon.co.uk/">Phil Sturgeon</a></li>
                     </ul>
                     <h2 class="epsilon">Project contributors</h2>
-                    <div id="contributors">Loading&hellip;</div>
+                    <div id="contributors">
+                    {% unless site.github.contributors.size == 0 or site.github.contributors.empty? %}
+                        <ul>
+                        {% for contributor in site.github.contributors %}
+                            <li><a href="{{ contributor.html_url }}" target="_blank">{{ contributor.login }}</a></li>
+                        {% endfor %}
+                        </ul>
+                    {% else %}
+                        <p>This project would not be possible without the help of <a href="https://github.com/codeguy/php-the-right-way/graphs/contributors">our amazing contributors</a> on GitHub.</p>
+                    {% endunless %}
+                    </div>
                     <h2 class="epsilon">Project sponsors</h2>
                     <ul class="mbd">
                         <li><a href="http://www.newmediacampaigns.com">New Media Campaigns</a></li>

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,31 +1,4 @@
 (function ($) {
-    // Load contributors
-    var $contributors = $('#contributors');
-    if ( $contributors.length ) {
-        var fail = function () {
-            $contributors.html('<p>This project would not be possible without the help of <a href="https://github.com/codeguy/php-the-right-way/graphs/contributors">our amazing contributors</a> on GitHub.</p>');
-        };
-        $.ajax({
-            cache: false,
-            dataType: 'jsonp',
-            timeout: 3000,
-            type: 'GET',
-            url: 'https://api.github.com/repos/codeguy/php-the-right-way/contributors?per_page=100'
-        }).done(function (data) {
-            if ( data.data && data.data.length ) {
-                var $ul = $('<ul></ul>'), dataLength = data.data.length;
-                for ( var i = 0; i < dataLength; i++ ) {
-                    $ul.append(['<li><a href="https://github.com/', data.data[i].login, '" target="_blank">', data.data[i].login, '</a></li>'].join(''));
-                }
-                $contributors.html($ul);
-            } else {
-                fail();
-            }
-        }).fail(fail);
-    }
-})(jQuery);
-
-(function ($) {
     //Add current view's highlighting to the navigation
     
     /** helper for highlighting */


### PR DESCRIPTION
Prevents running into the GH API rate limit of 60 calls per hour when using the API without OAuth (with OAuth would be irresponsible for a public repo, so this PR circumvents the need for that).

Ref:
- https://help.github.com/articles/repository-metadata-on-github-pages/
- https://developer.github.com/v3/repos/#list-contributors

---

We could even enrich the data a bit and choose to make it look pretty like in the below screenshot, but then I need some help on the .less front (as in: how to get the css to regen if I change something in the css?).

**_Note_**: The current PR does not change the styling or layout, just how the information is injected.

**Example of what could be:**

![screenshot](http://snag.gy/r3oEN.jpg)
