### PR TITLE
Added missing word

### DIFF
--- a/_posts/16-10-01-Books.md
+++ b/_posts/16-10-01-Books.md
@@ -30,4 +30,4 @@ security terms and provides some examples of them in every day PHP
 * [Signaling PHP]( https://leanpub.com/signalingphp) - PCNLT signals are a great help when writing PHP scripts that
 run from the command line.
 * [The Grumpy Programmer's Guide To Building Testable PHP Applications](https://leanpub.com/grumpy-testing) - Learning
-to write testable doesn't have to suck
+to write testable code doesn't have to suck


### PR DESCRIPTION
Added a missing word to the description about The Grumpy Programmer's Guide To Building Testable PHP Applications
