### PR TITLE
Fix link to Aura PHP.

### DIFF
--- a/_posts/16-07-01-Components.md
+++ b/_posts/16-07-01-Components.md
@@ -37,7 +37,7 @@ components best decoupled from the Laravel framework are listed above._
 [PEAR]: /#pear
 [Dependency Management]: /#dependency_management
 [FuelPHP Validation package]: https://github.com/fuelphp/validation
-[Aura]: http://auraphp.com/packages/v2
+[Aura]: http://auraphp.com/framework/2.x/en/
 [FuelPHP]: https://github.com/fuelphp
 [Hoa Project]: https://github.com/hoaproject
 [Orno]: https://github.com/orno


### PR DESCRIPTION
This patch fixes the broken link to Aura PHP that is on http://www.phptherightway.com/#components
