### PR TITLE
Updated AppFog link which was outdated

### DIFF
--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -6,7 +6,7 @@ anchor:  php_paas_providers
 ## PHP PaaS Providers {#php_paas_providers_title}
 
 * [PagodaBox](https://pagodabox.com/)
-* [AppFog](https://appfog.com/)
+* [AppFog](https://www.ctl.io/appfog/)
 * [Heroku](https://devcenter.heroku.com/categories/php)
 * [fortrabbit](http://fortrabbit.com/)
 * [Engine Yard Cloud](https://www.engineyard.com/products/cloud)


### PR DESCRIPTION
Seems that AppFog was acquired by CenturyLink, this is the new url: https://www.ctl.io/appfog/
