### PR TITLE
More PHP 7.0 Mac installation options

### DIFF
--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -15,7 +15,7 @@ There are multiple ways to install PHP on OS X.
 [Homebrew] is a powerful package manager for OS X, which can help you install PHP and various extensions easily.
 [Homebrew PHP] is a repository that contains PHP-related "formulae" for Homebrew, and will let you install PHP.
 
-At this point, you can install `php53`, `php54`, `php55` or `php56` using the `brew install` command, and switch
+At this point, you can install `php53`, `php54`, `php55`, `php56` or `php70` using the `brew install` command, and switch
 between them by modifying your `PATH` variable. Alternatively you can use [brew-php-switcher][brew-php-switcher] which will switch automatically for you.
 
 ### Install PHP via Macports
@@ -45,7 +45,7 @@ applications/projects require different versions of PHP, and you are not using v
 
 ### Install PHP via Liip's binary installer
 
-Another popular option is [php-osx.liip.ch] which provides one liner installation methods for versions 5.3 through 5.6.
+Another popular option is [php-osx.liip.ch] which provides one liner installation methods for versions 5.3 through 7.0.
 It doesn't overwrite the php binaries installed by Apple, but installs everything in a separate location (/usr/local/php5).
 
 ### Compile from Source


### PR DESCRIPTION
Homebrew and Liip's binary installer now also have PHP 7.0.
