### PR TITLE
Configuration update for Jekyll 3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,4 @@
 baseurl: /
-highlighter: pygments
-markdown: kramdown
 permalink: date
 maruku:
     use_tex:    false
@@ -20,3 +18,5 @@ defaults:
           sitemap: false
 
 exclude: ['CNAME', 'CONTRIBUTING.md', 'LICENSE', 'README.md', 'pages/example.md']
+
+future: true


### PR DESCRIPTION
GitHub Pages migrated to Jekyll 3 recently. As pointed out in #636 thanks to @jrfnl this patch fixes some not rendered posts such as community and resources. This blog post might also provide more info about Jekyll 3 migration:
https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0
