### PR TITLE
Improve word order

### DIFF
--- a/_posts/09-02-01-Errors.md
+++ b/_posts/09-02-01-Errors.md
@@ -48,7 +48,7 @@ changes to your code to help ensure best interoperability and forward compatibil
 
 Error Reporting can be changed by using PHP settings and/or PHP function calls. Using the built in PHP function
 `error_reporting()` you can set the level of errors for the duration of the script execution by passing one of the
-predefined error level constants, meaning if you only want to see Warnings and Errors - but not Notices - then you can
+predefined error level constants, meaning if you only want to see Errors and Warnings - but not Notices - then you can
 configure that:
 
 {% highlight php %}


### PR DESCRIPTION
Text should reflect the code: 

Errors and Warnings
`error_reporting(E_ERROR | E_WARNING);`

vs

Warnings and Errors
`error_reporting(E_ERROR | E_WARNING);`
