### PR TITLE
Removing CloudControl as it's being shut down

### DIFF
--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -13,7 +13,6 @@ anchor:  php_paas_providers
 * [Red Hat OpenShift Platform](http://openshift.com)
 * [dotCloud](https://www.dotcloud.com/dev-center/platform-documentation)
 * [AWS Elastic Beanstalk](http://aws.amazon.com/elasticbeanstalk/)
-* [cloudControl](https://www.cloudcontrol.com/)
 * [Windows Azure](http://www.windowsazure.com/)
 * [Google App Engine](https://developers.google.com/appengine/docs/php/gettingstarted/)
 * [Jelastic](http://jelastic.com/)


### PR DESCRIPTION
Also: should those be in alphabetical order? Or the idea is to favour some PaaS that are know to work better?
