### PR TITLE
Remove php.tools (a.k.a. phpfmt) in favor of PHP-CS-Fixer

### DIFF
--- a/_posts/02-01-01-Code-Style-Guide.md
+++ b/_posts/02-01-01-Code-Style-Guide.md
@@ -29,8 +29,7 @@ applications that implement the components can have consistency even when workin
 You can use [PHP_CodeSniffer][phpcs] to check code against any one of these recommendations, and plugins for text
 editors like [Sublime Text 2][st-cs] to be given real time feedback.
 
-You can fix the code layout automatically by using one of the two following tools. One is the [PHP Coding Standards Fixer][phpcsfixer] which has a very well tested codebase. 
-Another option is [php.tools][phptools], which is made popular by the [sublime-phpfmt][sublime-phpfmt] editor plugin. While being newer, it makes great improvements in performance, meaning real-time editor fixing is more fluid.
+Use Fabien Potencier's [PHP Coding Standards Fixer][phpcsfixer] to automatically modify your code syntax so that it conforms to these standards, saving you from fixing each problem by hand.
 
 And you can run phpcs manually from shell:
 
@@ -55,5 +54,3 @@ readable by all current and future parties who may be working on the codebase.
 [phpcs]: http://pear.php.net/package/PHP_CodeSniffer/
 [st-cs]: https://github.com/benmatselby/sublime-phpcs
 [phpcsfixer]: http://cs.sensiolabs.org/
-[phptools]: https://github.com/phpfmt/php.tools
-[sublime-phpfmt]: https://github.com/phpfmt/sublime-phpfmt


### PR DESCRIPTION
PHP-CS-Fixer has improved a lot, we should as a community to still support it in the scope of PSR-1/PSR-2.
