### PR TITLE
Adding a new PaaS provider Cloudways

### DIFF
--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -18,5 +18,6 @@ anchor:  php_paas_providers
 * [Google App Engine](https://developers.google.com/appengine/docs/php/gettingstarted/)
 * [Jelastic](http://jelastic.com/)
 * [Platform.sh](https://platform.sh/)
+* [Cloudways](https://www.cloudways.com/en/)
 
 To see which versions these PaaS hosts are running, head over to [PHP Versions](http://phpversions.info/paas-hosting/).


### PR DESCRIPTION
Cloudways is a Managed Cloud Hosting Platform for PHP based applications like PHP stack, WordPress, Magento, Prestashop, Joomla, Drupal etc.
- It is not focused on WordPress only. If a customer has a store on Magento, while a blog on WordPress, he can run both of them by using a single server.
- We provide users to choose server from four different cloud infrastuctures like DigitalOcean, Vultr, Amazon and Google Cloud. Yes, it is extremely easy to host on these infrastructures when you are with Cloudways.
-  What makes us different? Our customized, advanced caching stack technology, which includes the likes  of NGINX, Varnish, Memcached, Apache and Redis, that boosts page load performance. We promise a Page-load time of 50% less than the industry, owing to our optimized stack.
- Prices are Pay as You Go, with multiple pay options and plans suited to your needs.
- Improved UI and UX design. You can check out our feedback from different testers.
