### PR TITLE
Add word wrap in pre code blocks

### DIFF
--- a/styles/site/site-content.less
+++ b/styles/site/site-content.less
@@ -18,3 +18,10 @@
     font-size: 12px;
     text-decoration: none !important;
 }
+pre{
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
+}


### PR DESCRIPTION
The comments are very long and my screen is not large. I don' t like to scroll right and left in code blocks.
This should fix the problem.
[doc](https://www.longren.io/wrapping-text-inside-pre-tags/)
