### PR TITLE
XDebug.md: Corrected syntax (removed equals operator) in VHost snippet

### DIFF
--- a/_posts/03-06-01-XDebug.md
+++ b/_posts/03-06-01-XDebug.md
@@ -21,8 +21,8 @@ will want to enable right away.
 Traditionally, you will modify your Apache VHost or .htaccess file with these values:
 
 {% highlight ini %}
-php_value xdebug.remote_host=192.168.?.?
-php_value xdebug.remote_port=9000
+php_value xdebug.remote_host 192.168.?.?
+php_value xdebug.remote_port 9000
 {% endhighlight %}
 
 The "remote host" and "remote port" will correspond to your local computer and the port that you configure your IDE to


### PR DESCRIPTION
Hi, 

First-time contributor.  Just wanted to correct the syntax in the VHost snippet because it tripped me up when playing with XDebug remote debugging feature. 

Thanks! 
