### PR TITLE
Improve render of code example

### DIFF
--- a/_posts/08-03-01-Plain-PHP-Templates.md
+++ b/_posts/08-03-01-Plain-PHP-Templates.md
@@ -1,4 +1,5 @@
 ---
+title: Plain PHP Templates
 isChild: true
 anchor:  plain_php_templates
 ---

--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -1,4 +1,5 @@
 ---
+title: PHP PaaS Providers
 isChild: true
 anchor:  php_paas_providers
 ---

--- a/less/all.less
+++ b/less/all.less
@@ -139,6 +139,11 @@ pre{
 
     pre{
         padding: 5px 10px;
+        white-space: pre-wrap;
+        white-space: -moz-pre-wrap;
+        white-space: -pre-wrap;
+        white-space: -o-pre-wrap;
+        word-wrap: break-word;
     }
 }
 

--- a/styles/syntax.css
+++ b/styles/syntax.css
@@ -1,4 +1,4 @@
-.highlight  { background: #ffffff; }
+.highlight  { background: #ffffff; margin: 0 4px; font-size: 0.8em; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */
 .highlight .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .highlight .k { font-weight: bold } /* Keyword */


### PR DESCRIPTION
On mobile, code example is very difficult to read.

Before:
![www phptherightway com-pages-design-patterns html iphone 6 4](https://cloud.githubusercontent.com/assets/1461106/16559486/803ed43c-41ed-11e6-8bf3-4382e2da566d.png)

After:
![www phptherightway com-pages-design-patterns html iphone 6 6](https://cloud.githubusercontent.com/assets/1461106/16559498/87035720-41ed-11e6-9e65-9f048705c9ca.png)

Jean-Baptiste.
