### PR TITLE
Update the URL for php mentoring organization

### DIFF
--- a/_posts/16-04-01-Mentoring.md
+++ b/_posts/16-04-01-Mentoring.md
@@ -5,4 +5,4 @@ anchor:  mentoring
 
 ## Mentoring {#mentoring_title}
 
-* [phpmentoring.org](http://phpmentoring.org/) - Formal, peer to peer mentoring in the PHP community.
+* [php-mentoring.org](http://php-mentoring.org/) - Formal, peer to peer mentoring in the PHP community.


### PR DESCRIPTION
This fixes issue #663.

The original URL now points to a parked site.
