### PR TITLE
Fix jeckyll serve command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ included in the project:
     # Install the needed gems through Bundler
     bundle install
     # Run the local server
-    bundle execute jekyll s
+    bundle exec jekyll serve
     ```
 
 5. Commit your changes in logical chunks. Please adhere to these [git commit


### PR DESCRIPTION
This PR updates the local jeckyll generate server command ala https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/

Thereby fixing #670 
