### PR TITLE
Update Zend-db name and link

### DIFF
--- a/_posts/07-05-01-Abstraction-Layers.md
+++ b/_posts/07-05-01-Abstraction-Layers.md
@@ -18,12 +18,12 @@ installed in any application you like:
 * [Aura SQL][6]
 * [Doctrine2 DBAL][2]
 * [Propel][7]
-* [ZF2 Db][4]
+* [Zend-db][4]
 
 
 [1]: http://php.net/book.pdo
 [2]: http://www.doctrine-project.org/projects/dbal.html
-[4]: http://packages.zendframework.com/docs/latest/manual/en/index.html#zend-db
+[4]: https://packages.zendframework.com/docs/latest/manual/en/index.html#zendframework/zend-db
 [6]: https://github.com/auraphp/Aura.Sql
 [7]: http://propelorm.org/
 [psr0]: http://www.php-fig.org/psr/psr-0/


### PR DESCRIPTION
The anchor name for the Zend-db package has changed. This commit updates the link. It also changes the name to simply "Zend-db", which seems to be the new official name.
