### PR TITLE
Add new PaaS Provider

### DIFF
--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -20,5 +20,7 @@ anchor:  php_paas_providers
 * [Jelastic](http://jelastic.com/)
 * [Platform.sh](https://platform.sh/)
 * [Cloudways](https://www.cloudways.com/en/)
+* [IBM Bluemix Cloud Foundry](https://console.ng.bluemix.net/)
+* [Pivotal Web Service Cloud Foundry](https://run.pivotal.io/)
 
 To see which versions these PaaS hosts are running, head over to [PHP Versions](http://phpversions.info/paas-hosting/).


### PR DESCRIPTION
I added 2 paas provider in the list which are running under [Cloud Foundry](https://www.cloudfoundry.org/).

Bluemix is in the list of http://phpversions.info but it's not up to date and pivotal web service is not. I will do a PR to update http://phpversions.info
