### PR TITLE
Link to easy-to-read Read The Docs version rather than github repo

### DIFF
--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -11,7 +11,7 @@ make your code easier to manage and easier for others to understand.
 
 * [Architectural pattern on Wikipedia](https://en.wikipedia.org/wiki/Architectural_pattern)
 * [Software design pattern on Wikipedia](https://en.wikipedia.org/wiki/Software_design_pattern)
-* [Collection of implementation examples](https://github.com/domnikl/DesignPatternsPHP)
+* [Collection of implementation examples](http://designpatternsphp.readthedocs.io/en/latest/)
 
 ## Factory
 


### PR DESCRIPTION
The Read The Docs version is a nicely formatted version of the github version. It pulls directly from github, so it is just as up-to-date, yet has nicer formatting.

Read The Docs has a nice menu system; yet with github, one must be familiar with how markdown files are structured for this particular repo. Granted, a menu is provided "below the fold," but one must get over the intimidating github listing of files in order to know to scroll down to get to the rendering of the README.md file.

Fulfills part of #370 
