### PR TITLE
Fix headers capitalization

### DIFF
--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -1,4 +1,5 @@
 ---
+title:   Composer and Packagist
 isChild: true
 anchor:  composer_and_packagist
 ---

--- a/_posts/04-03-01-PEAR.md
+++ b/_posts/04-03-01-PEAR.md
@@ -1,4 +1,5 @@
 ---
+title:   PEAR
 isChild: true
 anchor:  pear
 ---

--- a/_posts/05-03-01-Date-and-Time.md
+++ b/_posts/05-03-01-Date-and-Time.md
@@ -1,4 +1,5 @@
 ---
+title:   Date and Time
 isChild: true
 anchor:  date_and_time
 ---

--- a/_posts/12-01-01-Servers-and-Deployment.md
+++ b/_posts/12-01-01-Servers-and-Deployment.md
@@ -1,4 +1,5 @@
 ---
+title:  Servers and Deployment
 anchor: servers_and_deployment
 ---
 

--- a/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
@@ -1,4 +1,5 @@
 ---
+title:   Virtual or Dedicated Servers
 isChild: true
 anchor:  virtual_or_dedicated_servers
 ---

--- a/_posts/16-02-01-From-the-Source.md
+++ b/_posts/16-02-01-From-the-Source.md
@@ -1,4 +1,5 @@
 ---
+title:   From the Source
 isChild: true
 anchor:  from_the_source
 ---

--- a/_posts/16-03-01-People-to-Follow.md
+++ b/_posts/16-03-01-People-to-Follow.md
@@ -1,4 +1,5 @@
 ---
+title:   People to Follow
 isChild: true
 anchor:  people_to_follow
 ---


### PR DESCRIPTION
If the title is not explicitly stated, it is generated from the filename.
It does not work fine for: "and", "or", "the" which should not be capitalized.

You can compare the current veresion with the "temporary" build on https://www.martinhujer.cz/php-the-right-way/
