### PR TITLE
Warn about composer update on production

### DIFF
--- a/_posts/04-02-01-Composer-and-Packagist.md
+++ b/_posts/04-02-01-Composer-and-Packagist.md
@@ -100,10 +100,11 @@ Now you can use your project dependencies, and they'll be autoloaded on demand.
 ### Updating your dependencies
 
 Composer creates a file called `composer.lock` which stores the exact version of each package it
-downloaded when you
-first ran `composer install`. If you share your project with other coders and the `composer.lock` file
-is part of your distribution, when they run `composer install` they'll get the same versions as you. 
-To update your dependencies, run `composer update`.
+downloaded when you first ran `composer install`. If you share your project with others, 
+ensure the `composer.lock` file is included, so that when they run `composer install` they'll 
+get the same versions as you.  To update your dependencies, run `composer update`. Don't use 
+`composer update` when deploying, only `composer install`, otherwise you may end up with different 
+package versions on production.
 
 This is most useful when you define your version requirements flexibly. For instance a version 
 requirement of `~1.8` means "anything newer than `1.8.0`, but less than `2.0.x-dev`". You can also use 


### PR DESCRIPTION
Also, greater encouragement to check composer.lock is staged in repositories.
Rephrased for (imho) improved clarity.
