### PR TITLE
Singleton  variable should be declared protected for inheritance to w…

### DIFF
--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -75,8 +75,8 @@ class Singleton
     /**
      * @var Singleton The reference to *Singleton* instance of this class
      */
-    private static $instance;
-    
+    protected static $instance;
+
     /**
      * Returns the *Singleton* instance of this class.
      *
@@ -87,7 +87,7 @@ class Singleton
         if (null === static::$instance) {
             static::$instance = new static();
         }
-        
+
         return static::$instance;
     }
 


### PR DESCRIPTION
In Singleton class, $instance should be declared protected instead of private for inheritance to work properly on subclasses.