### PR TITLE
Jekyll install improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /_site/
 *.DS_Store
 node_modules
+vendor
+.bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ included in the project:
 
     ```bash
     # Install the needed gems through Bundler
-    bundle install
+    bundle install --path vendor/bundle
     # Run the local server
     bundle exec jekyll serve
     ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ developers know where to find good information!
 
 ## How to Contribute
 
+You should read the `CONTRIBUTING.md` file for precise instructions and tips. But, if you prefer a TL;DR:
+
 1. Fork and edit
 2. Optionally install [Ruby](https://rvm.io/rvm/install/) with [Jekyll](https://github.com/mojombo/jekyll/) gem to preview locally
 3. Submit pull request for consideration

--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,6 @@ defaults:
       values:
           sitemap: false
 
-exclude: ['CNAME', 'CONTRIBUTING.md', 'LICENSE', 'README.md', 'pages/example.md']
+exclude: ['CNAME', 'CONTRIBUTING.md', 'LICENSE', 'README.md', 'pages/example.md', 'vendor']
 
 future: true


### PR DESCRIPTION
Took me some time to remember how to run the site locally, and I didn't notice this time there's a `CONTRIBUTING.md` file. I wonder if others stumble upon the same issue by only reading the README, so I added that.

Also, I noticed it's possible to install gems locally, much like Composer's default behavior, with the exception that [Bundler is not able to remove globally-installed gems for a given repo](http://stackoverflow.com/questions/21384664/how-to-uninstall-all-gems-installed-using-bundle-install); added that as well, for the sake of a clear computer.