### PR TITLE
Migrate directly to 7.1, not to 7.0

### DIFF
--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -6,11 +6,7 @@ anchor:  use_the_current_stable_version
 
 ## Use the Current Stable Version (7.1) {#use_the_current_stable_version_title}
 
-If you are getting started with PHP, start with the current stable release of [PHP 7.1][php-release]. PHP 7.1 is very
-new, and adds many amazing [new features](#language_highlights) over the older 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions.
-
-Most commonly in the near future you will find PHP 5.x being used, and the latest 5.x version is 5.6. This is not a bad option, but you should try to upgrade to the latest stable quickly - PHP 5.6 [will not receive security updates beyond 2018](http://php.net/supported-versions.php).  Upgrading is really quite easy, as there are not many [backwards compatibility breaks][php71-bc]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
+If you are getting started with PHP, start with the current stable release of [PHP 7.1](php-release). PHP 7.1 adds many amazing [new features](#language_highlights) over the older 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. Migration paths are [described in the PHP manual](php-migration-guides). 
 
 [php-release]: http://php.net/downloads.php
-[php-docs]: http://php.net/manual/
-[php71-bc]: http://php.net/manual/migration71.incompatible.php
+[php-migration-guides]: http://php.net/manual/en/appendices.php


### PR DESCRIPTION
It might be useful to warn users not to migrate to 7.0, even though it seems like a good idea. 