### PR TITLE
The "gems" Jekyll configuration option has been deprecated

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ maruku:
     png_dir:    images/latex
     png_url:    /images/latex
 
-gems:
+plugins:
     - jekyll-sitemap
 
 defaults:


### PR DESCRIPTION
Hello, the new Jekyll configuration option that also works on GitHub pages is now `plugins` instead of `gems`.

* https://help.github.com/articles/configuring-jekyll-plugins/