### PR TITLE
Remove PHP Security Cheat Sheet link

### DIFF
--- a/_posts/16-08-01-Sites.md
+++ b/_posts/16-08-01-Sites.md
@@ -10,7 +10,6 @@ title:   Other Useful Resources
 
 * [PHP Cheatsheets](http://phpcheatsheets.com/) - for variable comparisons, arithmetics and variable testing in various
 PHP versions
-* [PHP Security Cheatsheet](https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet)
 
 ### More best practices
 

--- a/_posts/16-08-01-Sites.md
+++ b/_posts/16-08-01-Sites.md
@@ -10,6 +10,7 @@ title:   Other Useful Resources
 
 * [PHP Cheatsheets](http://phpcheatsheets.com/) - for variable comparisons, arithmetics and variable testing in various
 PHP versions
+* [OWASP Security Cheatsheets](https://www.owasp.org/index.php/OWASP_Cheat_Sheet_Series) - provides a concise collection of high value information on specific application security topics. 
 
 ### More best practices
 


### PR DESCRIPTION
This link has been marked for deletion on the OWASP website. In light of this, perhaps the link should be removed from PHP The Right Way.

Related to and will close #799