### PR TITLE
Changed CLI name variable signature from optional to argument

### DIFF
--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -27,7 +27,7 @@ Let's write a simple "Hello, $name" CLI program. To try it out, create a file na
 {% highlight php %}
 <?php
 if ($argc !== 2) {
-    echo "Usage: php hello.php [name].\n";
+    echo "Usage: php hello.php <name>.\n";
     exit(1);
 }
 $name = $argv[1];
@@ -45,7 +45,7 @@ To run our script, above, from the command line:
 
 {% highlight console %}
 > php hello.php
-Usage: php hello.php [name]
+Usage: php hello.php <name>
 > php hello.php world
 Hello, world
 {% endhighlight %}


### PR DESCRIPTION
According to [docopt.org](http://docopt.org/) `[optional]`  and `<argument>` which by default is required.