### PR TITLE
change chinese translate website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You should read the `CONTRIBUTING.md` file for precise instructions and tips. Bu
 * [ภาษาไทย](https://apzentral.github.io/php-the-right-way/)
 * [한국어판](http://modernpug.github.io/php-the-right-way)
 * [日本語](http://ja.phptherightway.com)
-* [简体中文](http://laravel-china.github.io/php-the-right-way/)
+* [简体中文](http://phptherightway.p2hp.com/)
 * [繁體中文](http://laravel-taiwan.github.io/php-the-right-way)
 
 ### Translations

--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -39,7 +39,7 @@ _PHP: The Right Way_ is translated into many different languages:
 * [ภาษาไทย](https://apzentral.github.io/php-the-right-way/)
 * [한국어판](http://modernpug.github.io/php-the-right-way)
 * [日本語](http://ja.phptherightway.com)
-* [简体中文](http://laravel-china.github.io/php-the-right-way/)
+* [简体中文](http://phptherightway.p2hp.com/)
 * [繁體中文](http://laravel-taiwan.github.io/php-the-right-way)
 
 ## Book


### PR DESCRIPTION
change chinese translate website url,
the old website is not update,
the follow website continue update
http://phptherightway.p2hp.com/