### PR TITLE
Remove "Spread the Word!" link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,7 +38,6 @@
                     <ul>
                         <li><a href="/#translations">Translations</a></li>
                         <li><a href="/#how-to-contribute">How to Contribute</a></li>
-                        <li><a href="/#spread-the-word">Spread the Word!</a></li>
                     </ul>
                 </li>
                 {% assign lastIsChild = false %}


### PR DESCRIPTION
The relevant section no longer exists so this link provides no value.
closes #840 