### PR TITLE
Remove "Exception Best Practices in PHP 5.3" link

### DIFF
--- a/_posts/09-03-01-Exceptions.md
+++ b/_posts/09-03-01-Exceptions.md
@@ -74,4 +74,3 @@ standard Exception which is vague, or creating a custom Exception just for that,
 [exceptions]: https://secure.php.net/language.exceptions
 [splexe]: https://secure.php.net/spl.exceptions
 [nesting-exceptions-in-php]: https://www.brandonsavage.net/exceptional-php-nesting-exceptions-in-php/
-[exception-best-practices53]: http://ralphschindler.com/2010/09/15/exception-best-practices-in-php-5-3


### PR DESCRIPTION
Remove bad link "Exception Best Practices in PHP 5.3"

closes #847 