### PR TITLE
Fix PHPDoc URLs

### DIFF
--- a/_posts/15-02-01-PHPDoc.md
+++ b/_posts/15-02-01-PHPDoc.md
@@ -70,10 +70,10 @@ difference between the second and third methods' doc block is the inclusion/excl
 `@return void` explicitly informs us that there is no return; historically omitting the `@return void` statement also results in the same (no return) action.
 
 
-[tags]: https://docs.phpdoc.org/references/phpdoc/tags/index.html
-[PHPDoc manual]: https://docs.phpdoc.org/index.html
-[@author]: https://docs.phpdoc.org/references/phpdoc/tags/author.html
-[@link]: https://docs.phpdoc.org/references/phpdoc/tags/link.html
-[@param]: https://docs.phpdoc.org/references/phpdoc/tags/param.html
-[@return]: https://docs.phpdoc.org/references/phpdoc/tags/return.html
-[@throws]: https://docs.phpdoc.org/references/phpdoc/tags/throws.html
+[tags]: https://docs.phpdoc.org/latest/references/phpdoc/tags/index.html
+[PHPDoc manual]: https://docs.phpdoc.org/latest/index.html
+[@author]: https://docs.phpdoc.org/latest/references/phpdoc/tags/author.html
+[@link]: https://docs.phpdoc.org/latest/references/phpdoc/tags/link.html
+[@param]: https://docs.phpdoc.org/latest/references/phpdoc/tags/param.html
+[@return]: https://docs.phpdoc.org/latest/references/phpdoc/tags/return.html
+[@throws]: https://docs.phpdoc.org/latest/references/phpdoc/tags/throws.html


### PR DESCRIPTION
Links to docs.phpdoc.org were broken. They now scope everything under /latest.