### PR TITLE
Remove Missing Link

### DIFF
--- a/_posts/09-03-01-Exceptions.md
+++ b/_posts/09-03-01-Exceptions.md
@@ -67,7 +67,6 @@ standard Exception which is vague, or creating a custom Exception just for that,
 * [Read about Exceptions][exceptions]
 * [Read about SPL Exceptions][splexe]
 * [Nesting Exceptions In PHP][nesting-exceptions-in-php]
-* [Exception Best Practices in PHP 5.3][exception-best-practices53]
 
 
 [splext]: /#standard_php_library


### PR DESCRIPTION
Link reference was removed in f0cee4dd4370e0835cc38ccbc5fedacb9a04558c but the actual link was missed.