### PR TITLE
Update puphpet link

### DIFF
--- a/_posts/13-02-01-Vagrant.md
+++ b/_posts/13-02-01-Vagrant.md
@@ -29,7 +29,5 @@ document controls everything that is installed on the virtual machine.
 [Vagrant]: https://www.vagrantup.com/
 [Puppet]: https://puppet.com/
 [Chef]: https://www.chef.io/
-[Rove]: http://rove.io/
-[Puphpet]: https://puphpet.com/
-[Protobox]: https://www.getprotobox.com/
+[Puphpet]: https://github.com/puphpet/puphpet
 [Phansible]: http://phansible.com/


### PR DESCRIPTION
The service is down for good but the code is still on github. 
https://github.com/puphpet/puphpet/issues/2855

Clean up links to Rove and protobox.