### PR TITLE
Recommend PHP 8.0

### DIFF
--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -1,15 +1,15 @@
 ---
-title:   Use the Current Stable Version (7.4)
+title:   Use the Current Stable Version (8.0)
 isChild: true
 anchor:  use_the_current_stable_version
 ---
 
-## Use the Current Stable Version (7.4) {#use_the_current_stable_version_title}
+## Use the Current Stable Version (8.0) {#use_the_current_stable_version_title}
 
-If you are getting started with PHP, start with the current stable release of [PHP 7.4][php-release]. PHP 7.x adds many [new features](#language_highlights) over the older 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions.
+If you are getting started with PHP, start with the current stable release of [PHP 8.0][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x and 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8.0 is a major update of the language and contains many new features and optimizations.
 
-You should try to upgrade to the latest stable version quickly - PHP 5.6 [is already End of Life](http://php.net/supported-versions.php).  Upgrading is easy, as there are not many [backwards compatibility breaks][php74-bc]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
+You should try to upgrade to the latest stable version quickly - PHP 5.6 [is already End of Life](http://php.net/supported-versions.php). Upgrading is easy, as there are not many [backwards compatibility breaks][php-bc]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
 
 [php-release]: http://php.net/downloads.php
 [php-docs]: http://php.net/manual/
-[php74-bc]: http://php.net/manual/migration74.incompatible.php
+[php-bc]: http://php.net/manual/migration80.incompatible.php

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -9,10 +9,10 @@ macOS comes prepackaged with PHP but it is normally a little behind the latest s
 
 ### Install PHP via Homebrew
 
-[Homebrew] is a package manager for macOS that helps you easily install PHP and various extensions. The Homebrew core repository provides "formulae" for PHP 5.6, 7.0, 7.1, 7.2, 7.3 and 7.4. Install the latest version with this command:
+[Homebrew] is a package manager for macOS that helps you easily install PHP and various extensions. The Homebrew core repository provides "formulae" for PHP 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, and PHP 8.0. Install the latest version with this command:
 
 ```
-brew install php@7.4
+brew install php@8.0
 ```
 
 You can switch between Homebrew PHP versions by modifying your `PATH` variable. Alternatively, you can use [brew-php-switcher][brew-php-switcher] to switch PHP versions automatically.
@@ -28,14 +28,14 @@ MacPorts supports pre-compiled binaries, so you don't need to recompile every
 dependency from the source tarball files, it saves your life if you don't
 have any package installed on your system.
 
-At this point, you can install `php54`, `php55`, `php56`, `php70`, `php71`, `php72`, `php73` or `php74` using the `port install` command, for example:
+At this point, you can install `php54`, `php55`, `php56`, `php70`, `php71`, `php72`, `php73`, `php74` or `php80` using the `port install` command, for example:
 
-    sudo port install php56
     sudo port install php74
+    sudo port install php80
 
 And you can run `select` command to switch your active PHP:
 
-    sudo port select --set php php74
+    sudo port select --set php php80
 
 ### Install PHP via phpbrew
 


### PR DESCRIPTION
Hello, PHP 8.0 has been released in December 2020. Maybe it's time to recommend it already.

I've changed things in the most possible minimal way. Hopefully it's fine, otherwise ping me back to adjust the sentences more.

Thank you.