### PR TITLE
Removed outdated summary

### DIFF
--- a/_posts/16-08-01-Sites.md
+++ b/_posts/16-08-01-Sites.md
@@ -15,7 +15,6 @@ PHP versions
 ### More best practices
 
 * [PHP Best Practices](https://phpbestpractices.org/)
-* [Best practices for Modern PHP Development](https://www.airpair.com/php/posts/best-practices-for-modern-php-development)
 * [Why You Should Be Using Supported PHP Versions](https://kinsta.com/blog/php-versions/)
 
 ### News around the PHP and web development communities


### PR DESCRIPTION
The guide is for version 5.6 and while not completely outdated, still too much outdated information to be of use.