### PR TITLE
The site no longer exists (but the domain)

### DIFF
--- a/_posts/16-04-01-Mentoring.md
+++ b/_posts/16-04-01-Mentoring.md
@@ -1,8 +1,0 @@
----
-isChild: true
-anchor:  mentoring
----
-
-## Mentoring {#mentoring_title}
-
-* [php-mentoring.org](https://php-mentoring.org/) - Formal, peer to peer mentoring in the PHP community.


### PR DESCRIPTION
It seems like https://php-mentoring.org/ is dead. The repo to that page is inactive, too.