### PR TITLE
Fix PHPDoc URLs

### DIFF
--- a/_posts/15-02-01-PHPDoc.md
+++ b/_posts/15-02-01-PHPDoc.md
@@ -70,10 +70,10 @@ difference between the second and third methods' doc block is the inclusion/excl
 `@return void` explicitly informs us that there is no return; historically omitting the `@return void` statement also results in the same (no return) action.
 
 
-[tags]: https://docs.phpdoc.org/latest/references/phpdoc/tags/index.html
+[tags]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/index.html
 [PHPDoc manual]: https://docs.phpdoc.org/latest/index.html
-[@author]: https://docs.phpdoc.org/latest/references/phpdoc/tags/author.html
-[@link]: https://docs.phpdoc.org/latest/references/phpdoc/tags/link.html
-[@param]: https://docs.phpdoc.org/latest/references/phpdoc/tags/param.html
-[@return]: https://docs.phpdoc.org/latest/references/phpdoc/tags/return.html
-[@throws]: https://docs.phpdoc.org/latest/references/phpdoc/tags/throws.html
+[@author]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/author.html
+[@link]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/link.html
+[@param]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/param.html
+[@return]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/return.html
+[@throws]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/throws.html


### PR DESCRIPTION
This fixes few URLs for the PHPDoc. They now need to have additional `guide` in the URL.

Thank you.