### PR TITLE
Adjusted URLs for deprecated packages

### DIFF
--- a/_posts/05-05-01-PHP-and-UTF8.md
+++ b/_posts/05-05-01-PHP-and-UTF8.md
@@ -41,11 +41,11 @@ encoding. You should always explicitly indicate UTF-8 when given the option. For
 option for character encoding, and you should always specify UTF-8 if dealing with such strings. Note that as of PHP 5.4.0, UTF-8 is the default encoding for `htmlentities()` and `htmlspecialchars()`.
 
 Finally, If you are building a distributed application and cannot be certain that the `mbstring` extension will be
-enabled, then consider using the [patchwork/utf8] Composer package. This will use `mbstring` if it is available, and
+enabled, then consider using the [symfony/polyfill-mbstring] Composer package. This will use `mbstring` if it is available, and
 fall back to non UTF-8 functions if not.
 
 [Multibyte String Extension]: https://secure.php.net/book.mbstring
-[patchwork/utf8]: https://packagist.org/packages/patchwork/utf8
+[symfony/polyfill-mbstring]: https://packagist.org/packages/symfony/polyfill-mbstring
 
 ### UTF-8 at the Database level
 

--- a/_posts/05-06-01-Internationalization-and-Localization.md
+++ b/_posts/05-06-01-Internationalization-and-Localization.md
@@ -49,7 +49,7 @@ to other formats besides `.mo/.po` files. Can be useful if you need to integrate
 parts of the system, like a JavaScript interface.
 - [symfony/translation][symfony]: supports a lot of different formats, but recommends using verbose XLIFF's. Doesn't
 include helper functions nor a built-in extractor, but supports placeholders using `strtr()` internally.
-- [zend/i18n][zend]: supports array and INI files, or Gettext formats. Implements a caching layer to save you from
+- [laminas/laminas-i18n][laminas]: supports array and INI files, or Gettext formats. Implements a caching layer to save you from
 reading the filesystem every time. It also includes view helpers, and locale-aware input filters and validators.
 However, it has no message extractor.
 
@@ -413,7 +413,7 @@ After including those new rules in the `.po` file, a new scan will bring in your
 [aura-intl]: https://github.com/auraphp/Aura.Intl
 [oscarotero]: https://github.com/oscarotero/Gettext
 [symfony]: https://symfony.com/doc/current/components/translation.html
-[zend]: https://docs.zendframework.com/zend-i18n/translation
+[laminas]: https://docs.laminas.dev/laminas-i18n/
 [laravel]: https://laravel.com/docs/master/localization
 [yii]: https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n
 [intl]: https://secure.php.net/manual/intro.intl.php


### PR DESCRIPTION
zend/i18n is now laminas/laminas-i18n and patchwork/utf8 is deprecated, symfony/polyfill-mbstring is the appropriate substitute