### PR TITLE
Update the current working APC docs

### DIFF
--- a/_posts/14-02-01-Opcode-Cache.md
+++ b/_posts/14-02-01-Opcode-Cache.md
@@ -23,7 +23,7 @@ Read more about opcode caches:
 
 
 [opcache-book]: https://secure.php.net/book.opcache
-[APC]: https://secure.php.net/book.apc
+[APC]: https://www.php.net/book.apcu
 [XCache]: https://xcache.lighttpd.net/
 [Zend Optimizer+]: https://github.com/zendtech/ZendOptimizerPlus
 [WinCache]: https://www.iis.net/downloads/microsoft/wincache-extension


### PR DESCRIPTION
The previous docs link isn't found on the php.net website but there is docs for APC
so this patch just updates to the current valid docs on the website.