### PR TITLE
Add Medoo link to database abstraction layers

### DIFF
--- a/_posts/07-05-01-Abstraction-Layers.md
+++ b/_posts/07-05-01-Abstraction-Layers.md
@@ -18,6 +18,7 @@ installed in any application you like:
 * [Atlas][5]
 * [Aura SQL][6]
 * [Doctrine2 DBAL][2]
+* [Medoo][8]
 * [Propel][7]
 * [Zend-db][4]
 
@@ -28,5 +29,6 @@ installed in any application you like:
 [5]: https://atlasphp.io
 [6]: https://github.com/auraphp/Aura.Sql
 [7]: http://propelorm.org/
+[8]: https://medoo.in/
 [psr0]: https://www.php-fig.org/psr/psr-0/
 [psr4]: https://www.php-fig.org/psr/psr-4/


### PR DESCRIPTION
Added a Medoo official website link to the database abstraction layers list.

Of course, it would be better to write a new section to introduce how Medoo operates the database and work with other frameworks like https://medoo.in/api/collaboration.