### PR TITLE
Remove broken (and outdated) link to PHP opcode list.

### DIFF
--- a/_posts/14-02-01-Opcode-Cache.md
+++ b/_posts/14-02-01-Opcode-Cache.md
@@ -5,7 +5,7 @@ anchor:  opcode_cache
 
 ## Opcode Cache {#opcode_cache_title}
 
-When a PHP file is executed, it must first be compiled into [opcodes](https://secure.php.net/manual/internals2.opcodes.php) (machine language instructions for the CPU). If the source code is unchanged, the opcodes will be the same, so this compilation step becomes a waste of CPU resources.
+When a PHP file is executed, it must first be compiled into [opcodes](https://php-legacy-docs.zend.com/manual/php5/en/internals2.opcodes) (machine language instructions for the CPU). If the source code is unchanged, the opcodes will be the same, so this compilation step becomes a waste of CPU resources.
 
 An opcode cache prevents redundant compilation by storing opcodes in memory and reusing them on successive calls. It will typically check signature or modification time of the file first, in case there have been any changes.
 

--- a/_posts/14-02-01-Opcode-Cache.md
+++ b/_posts/14-02-01-Opcode-Cache.md
@@ -5,7 +5,7 @@ anchor:  opcode_cache
 
 ## Opcode Cache {#opcode_cache_title}
 
-When a PHP file is executed, it must first be compiled into [opcodes](https://php-legacy-docs.zend.com/manual/php5/en/internals2.opcodes) (machine language instructions for the CPU). If the source code is unchanged, the opcodes will be the same, so this compilation step becomes a waste of CPU resources.
+When a PHP file is executed, it must first be compiled into opcodes (machine language instructions for the CPU). If the source code is unchanged, the opcodes will be the same, so this compilation step becomes a waste of CPU resources.
 
 An opcode cache prevents redundant compilation by storing opcodes in memory and reusing them on successive calls. It will typically check signature or modification time of the file first, in case there have been any changes.
 


### PR DESCRIPTION
The link previously contained was dead, as it doesn't seem to appear in the current version or mirrors of the PHP source code, but does appear in Zend's 5.x documentation mirror.

Unfortunately, it doesn't look like Zend has a language agnostic link, so I've sourced the English one. If anyone knows of one that isn't exclusively English that'd be great.