### PR TITLE
Dwoo library removed from the list of Libraries

### DIFF
--- a/_posts/08-05-01-Further-Reading.md
+++ b/_posts/08-05-01-Further-Reading.md
@@ -20,7 +20,6 @@ anchor:  templating_further_reading
 * [Aura.View](https://github.com/auraphp/Aura.View) *(native)*
 * [Blade](https://laravel.com/docs/blade) *(compiled, framework specific)*
 * [Brainy](https://github.com/box/brainy) *(compiled)*
-* [Dwoo](http://dwoo.org/) *(compiled)*
 * [Latte](https://github.com/nette/latte) *(compiled)*
 * [Mustache](https://github.com/bobthecow/mustache.php) *(compiled)*
 * [PHPTAL](https://phptal.org/) *(compiled)*


### PR DESCRIPTION
Dwoo library has been removed due that Dwoo project has been discounted and the link within the PHP The Right Way documentation links to a gambling website. Issue #919  