### PR TITLE
Replace Zend/View link

### DIFF
--- a/_posts/08-05-01-Further-Reading.md
+++ b/_posts/08-05-01-Further-Reading.md
@@ -27,4 +27,4 @@ anchor:  templating_further_reading
 * [Plates](http://platesphp.com/) *(native)*
 * [Smarty](https://www.smarty.net/) *(compiled)*
 * [Twig](https://twig.symfony.com/) *(compiled)*
-* [Zend\View](https://framework.zend.com/manual/2.3/en/modules/zend.view.quick-start.html) *(native, framework specific)*
+* [Zend\View](https://framework.zend.com/manual/2.4/en/modules/zend.view.quick-start.html) *(native, framework specific)*


### PR DESCRIPTION
Replaced the Zend/View with a new link due that the current link to Zend/View found in the PHP The Right Way documentation resolves to 500 Internal Server Error. Issue #920 