### PR TITLE
Update redirected links

### DIFF
--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -82,5 +82,5 @@ you and tie them all together, but ease of setup comes with a trade-off of flexi
 [apache]: https://httpd.apache.org/
 [nginx]: https://www.nginx.com/
 [mamp-downloads]: https://www.mamp.info/en/downloads/
-[xampp]: https://www.apachefriends.org/index.html
+[xampp]: https://www.apachefriends.org/
 [brew-php-switcher]: https://github.com/philcook/brew-php-switcher

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -31,4 +31,4 @@ Chris Tankersley has a very helpful blog post on what tools he uses to do [PHP d
 [php-iis]: https://php.iis.net/
 [windows-path]: https://www.windows-commandline.com/set-path-command-line/
 [windows-tools]: https://ctankersley.com/2016/11/13/developing-on-windows-2016/
-[xampp]: http://www.apachefriends.org/en/xampp.html
+[xampp]: http://www.apachefriends.org/

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -23,12 +23,12 @@ live. If you are developing on Windows and deploying to Linux (or anything non-W
 
 Chris Tankersley has a very helpful blog post on what tools he uses to do [PHP development using Windows][windows-tools].
 
-[easyphp]: http://www.easyphp.org/
+[easyphp]: https://www.easyphp.org/
 [phpmanager]: http://phpmanager.codeplex.com/
 [openserver]: http://open-server.ru/
-[wamp]: http://www.wampserver.com/en/
-[php-downloads]: http://windows.php.net/download/
-[php-iis]: http://php.iis.net/
-[windows-path]: http://www.windows-commandline.com/set-path-command-line/
-[windows-tools]: http://ctankersley.com/2016/11/13/developing-on-windows-2016/
+[wamp]: https://www.wampserver.com/en/
+[php-downloads]: https://windows.php.net/download/
+[php-iis]: https://php.iis.net/
+[windows-path]: https://www.windows-commandline.com/set-path-command-line/
+[windows-tools]: https://ctankersley.com/2016/11/13/developing-on-windows-2016/
 [xampp]: http://www.apachefriends.org/en/xampp.html

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -25,7 +25,7 @@ Chris Tankersley has a very helpful blog post on what tools he uses to do [PHP d
 
 [easyphp]: https://www.easyphp.org/
 [phpmanager]: http://phpmanager.codeplex.com/
-[openserver]: http://open-server.ru/
+[openserver]: https://ospanel.io/
 [wamp]: https://www.wampserver.com/en/
 [php-downloads]: https://windows.php.net/download/
 [php-iis]: https://php.iis.net/

--- a/_posts/05-06-01-Internationalization-and-Localization.md
+++ b/_posts/05-06-01-Internationalization-and-Localization.md
@@ -418,7 +418,7 @@ After including those new rules in the `.po` file, a new scan will bring in your
 [yii]: https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n
 [intl]: https://secure.php.net/manual/intro.intl.php
 [ICU project]: https://icu.unicode.org/
-[symfony-keys]: https://symfony.com/doc/current/components/translation/usage.html#creating-translations
+[symfony-keys]: https://symfony.com/doc/current/translation.html#using-real-or-keyword-messages
 
 [sprintf]: https://secure.php.net/manual/function.sprintf.php
 [func]: https://secure.php.net/manual/function.gettext.php

--- a/_posts/05-06-01-Internationalization-and-Localization.md
+++ b/_posts/05-06-01-Internationalization-and-Localization.md
@@ -417,7 +417,7 @@ After including those new rules in the `.po` file, a new scan will bring in your
 [laravel]: https://laravel.com/docs/master/localization
 [yii]: https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n
 [intl]: https://secure.php.net/manual/intro.intl.php
-[ICU project]: http://www.icu-project.org
+[ICU project]: https://icu.unicode.org/
 [symfony-keys]: https://symfony.com/doc/current/components/translation/usage.html#creating-translations
 
 [sprintf]: https://secure.php.net/manual/function.sprintf.php

--- a/_posts/05-06-01-Internationalization-and-Localization.md
+++ b/_posts/05-06-01-Internationalization-and-Localization.md
@@ -412,7 +412,7 @@ After including those new rules in the `.po` file, a new scan will bring in your
 [func_format]: https://www.gnu.org/software/gettext/manual/gettext.html#Language-specific-options
 [aura-intl]: https://github.com/auraphp/Aura.Intl
 [oscarotero]: https://github.com/oscarotero/Gettext
-[symfony]: https://symfony.com/doc/current/components/translation.html
+[symfony]: https://symfony.com/components/Translation
 [laminas]: https://docs.laminas.dev/laminas-i18n/
 [laravel]: https://laravel.com/docs/master/localization
 [yii]: https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n

--- a/_posts/06-05-01-Further-Reading.md
+++ b/_posts/06-05-01-Further-Reading.md
@@ -5,7 +5,7 @@ anchor:  further_reading
 
 ## Further Reading {#further_reading_title}
 
-* [What is Dependency Injection?](http://fabien.potencier.org/article/11/what-is-dependency-injection)
+* [What is Dependency Injection?](http://fabien.potencier.org/what-is-dependency-injection.html)
 * [Dependency Injection: An analogy](https://mwop.net/blog/260-Dependency-Injection-An-analogy.html)
 * [Dependency Injection: Huh?](https://code.tutsplus.com/tutorials/dependency-injection-huh--net-26903)
 * [Dependency Injection as a tool for testing](https://medium.com/philipobenito/dependency-injection-as-a-tool-for-testing-902c21c147f1)

--- a/_posts/08-04-01-Compiled-Templates.md
+++ b/_posts/08-04-01-Compiled-Templates.md
@@ -67,7 +67,7 @@ Using the [Twig] library.
 {% endhighlight %}
 
 
-[article_templating_engines]: http://fabien.potencier.org/article/34/templating-engines-in-php
+[article_templating_engines]: http://fabien.potencier.org/templating-engines-in-php.html
 [Twig]: https://twig.symfony.com/
 [Brainy]: https://github.com/box/brainy
 [Smarty]: https://www.smarty.net/

--- a/_posts/08-05-01-Further-Reading.md
+++ b/_posts/08-05-01-Further-Reading.md
@@ -7,7 +7,7 @@ anchor:  templating_further_reading
 
 ### Articles & Tutorials
 
-* [Templating Engines in PHP](http://fabien.potencier.org/article/34/templating-engines-in-php)
+* [Templating Engines in PHP](http://fabien.potencier.org/templating-engines-in-php.html)
 * [An Introduction to Views & Templating in CodeIgniter](https://code.tutsplus.com/tutorials/an-introduction-to-views-templating-in-codeigniter--net-25648)
 * [Getting Started With PHP Templating](https://www.smashingmagazine.com/2011/10/getting-started-with-php-templating/)
 * [Roll Your Own Templating System in PHP](https://code.tutsplus.com/tutorials/roll-your-own-templating-system-in-php--net-16596)

--- a/_posts/10-02-01-Web-Application-Security.md
+++ b/_posts/10-02-01-Web-Application-Security.md
@@ -36,7 +36,7 @@ methods to protect yourself against them. This is a must read for the security-c
 [2]: https://www.owasp.org/index.php/Guide_Table_of_Contents
 [3]: https://phpsecurity.readthedocs.io/en/latest/index.html
 [4]: https://paragonie.com/blog/2015/08/gentle-introduction-application-security
-[5]: http://searchsecurity.techtarget.com/definition/address-space-layout-randomization-ASLR
+[5]: https://www.techtarget.com/searchsecurity/definition/address-space-layout-randomization-ASLR
 [6]: https://paragonie.com/blog/2016/01/on-design-and-implementation-stealth-backdoor-for-web-applications
 [7]: https://paragonie.com/blog/2015/05/using-encryption-and-authentication-correctly
 [8]: https://blog.ircmaxell.com/2014/11/its-all-about-time.html

--- a/_posts/10-02-01-Web-Application-Security.md
+++ b/_posts/10-02-01-Web-Application-Security.md
@@ -39,5 +39,4 @@ methods to protect yourself against them. This is a must read for the security-c
 [5]: http://searchsecurity.techtarget.com/definition/address-space-layout-randomization-ASLR
 [6]: https://paragonie.com/blog/2016/01/on-design-and-implementation-stealth-backdoor-for-web-applications
 [7]: https://paragonie.com/blog/2015/05/using-encryption-and-authentication-correctly
-[8]: http://blog.ircmaxell.com/2014/11/its-all-about-time.html
-
+[8]: https://blog.ircmaxell.com/2014/11/its-all-about-time.html

--- a/_posts/11-02-01-Test-Driven-Development.md
+++ b/_posts/11-02-01-Test-Driven-Development.md
@@ -62,7 +62,7 @@ users of the application.
 
 #### Functional Testing Tools
 
-* [Selenium](https://docs.seleniumhq.org/)
+* [Selenium](https://www.selenium.dev/)
 * [Mink](https://mink.behat.org/)
 * [Codeception](https://codeception.com/) is a full-stack testing framework that includes acceptance testing tools
 * [Storyplayer](https://datasift.github.io/storyplayer/) is a full-stack testing framework that includes support for creating and destroying test environments on demand

--- a/_posts/11-02-01-Test-Driven-Development.md
+++ b/_posts/11-02-01-Test-Driven-Development.md
@@ -63,6 +63,6 @@ users of the application.
 #### Functional Testing Tools
 
 * [Selenium](https://docs.seleniumhq.org/)
-* [Mink](http://mink.behat.org/)
+* [Mink](https://mink.behat.org/)
 * [Codeception](https://codeception.com/) is a full-stack testing framework that includes acceptance testing tools
 * [Storyplayer](https://datasift.github.io/storyplayer/) is a full-stack testing framework that includes support for creating and destroying test environments on demand

--- a/_posts/11-03-01-Behavior-Driven-Development.md
+++ b/_posts/11-03-01-Behavior-Driven-Development.md
@@ -24,7 +24,7 @@ purpose. This framework is inspired by the [RSpec project][Rspec] for Ruby.
 * [Codeception] is a full-stack testing framework that uses BDD principles.
 
 
-[Behat]: http://behat.org/
+[Behat]: https://behat.org/
 [Cucumber]: https://cucumber.io/
 [PHPSpec]: https://www.phpspec.net/
 [RSpec]: https://rspec.info/

--- a/_posts/11-04-01-Complementary-Testing-Tools.md
+++ b/_posts/11-04-01-Complementary-Testing-Tools.md
@@ -19,7 +19,7 @@ libraries useful for any preferred approach taken.
 * [PHPUnit Polyfills] is a library that allows for creating PHPUnit cross-version compatible tests when a test suite needs to run against a range of PHPUnit versions.
 
 
-[Selenium]: https://www.seleniumhq.org/
+[Selenium]: https://www.selenium.dev/
 [integrated with PHPUnit]: https://github.com/giorgiosironi/phpunit-selenium/
 [Mockery]: https://github.com/padraic/mockery
 [PHPUnit]: https://phpunit.de/

--- a/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
@@ -54,7 +54,7 @@ If you are running Apache 2.4 or later, you can use [mod_proxy_fcgi] to get grea
 [event MPM]: https://httpd.apache.org/docs/2.4/mod/event.html
 [apache]: https://httpd.apache.org/
 [apache-MPM]: https://httpd.apache.org/docs/2.4/mod/mpm_common.html
-[mod_fastcgi]: https://blogs.oracle.com/opal/entry/php_fpm_fastcgi_process_manager
+[mod_fastcgi]: https://blogs.oracle.com/opal/post/php-fpm-fastcgi-process-manager-with-apache-2
 [mod_fcgid]: hhttps://httpd.apache.org/mod_fcgid/
 [mod_proxy_fcgi]: https://httpd.apache.org/docs/current/mod/mod_proxy_fcgi.html
 [tutorial-mod_proxy_fcgi]: https://serversforhackers.com/video/apache-and-php-fpm

--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -94,7 +94,7 @@ PHP.
 [Chef_cookbook]: https://github.com/chef-cookbooks/php
 [Chef_tutorial]: https://www.youtube.com/playlist?list=PL11cZfNdwNyPnZA9D1MbVqldGuOWqbumZ
 [apache_ant_tutorial]: https://code.tutsplus.com/tutorials/automate-your-projects-with-apache-ant--net-18595
-[Travis CI]: https://travis-ci.org/
+[Travis CI]: https://www.travis-ci.com/
 [Jenkins]: https://jenkins.io/
 [PHPCI]: https://github.com/dancryer/phpci
 [PHP Censor]: https://github.com/php-censor/php-censor

--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -86,7 +86,7 @@ PHP.
 [buildautomation]: https://wikipedia.org/wiki/Build_automation
 [Phing]: https://www.phing.info/
 [Apache Ant]: https://ant.apache.org/
-[Capistrano]: http://capistranorb.com/
+[Capistrano]: https://capistranorb.com/
 [Ansistrano]: https://ansistrano.com
 [phpdeploy_deployer]: https://www.sitepoint.com/deploying-php-applications-with-deployer/
 [Chef]: https://www.chef.io/

--- a/_posts/13-03-01-Docker.md
+++ b/_posts/13-03-01-Docker.md
@@ -39,6 +39,6 @@ The [PHPDocker.io] site will auto-generate all the files you need for a fully-fe
 [Docker]: https://www.docker.com/
 [docker-hub]: https://hub.docker.com/
 [docker-hub-official]: https://hub.docker.com/explore/
-[docker-install]: https://docs.docker.com/install/
+[docker-install]: https://docs.docker.com/get-docker/
 [docker-doc]: https://docs.docker.com/
-[PHPDocker.io]: https://phpdocker.io/generator
+[PHPDocker.io]: https://phpdocker.io/

--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -11,7 +11,7 @@ anchor:  php_paas_providers
 * [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
 * [Cloudways](https://www.cloudways.com/)
 * [Divio](https://www.divio.com/php/)
-* [Engine Yard Cloud](https://www.engineyard.com/features)
+* [Engine Yard Cloud](https://www.engineyard.com/)
 * [fortrabbit](https://www.fortrabbit.com/)
 * [Google App Engine](https://cloud.google.com/appengine/docs/php/)
 * [Heroku](https://devcenter.heroku.com/categories/php-support)

--- a/_posts/16-07-01-Components.md
+++ b/_posts/16-07-01-Components.md
@@ -47,7 +47,7 @@ components best decoupled from the Laravel framework are listed above._
 [Aura]: http://auraphp.com/framework/
 [FuelPHP]: https://github.com/fuelphp
 [Hoa Project]: https://github.com/hoaproject
-[Symfony Components]: https://symfony.com/doc/current/components/index.html
+[Symfony Components]: https://symfony.com/components
 [The League of Extraordinary Packages]: https://thephpleague.com/
 [IoC Container]: https://github.com/illuminate/container
 [Eloquent ORM]: https://github.com/illuminate/database

--- a/_posts/16-08-01-Sites.md
+++ b/_posts/16-08-01-Sites.md
@@ -10,7 +10,7 @@ title:   Other Useful Resources
 
 * [PHP Cheatsheets](http://phpcheatsheets.com/) - for variable comparisons, arithmetics and variable testing in various PHP versions.
 * [Modern PHP Cheatsheet](https://github.com/smknstd/modern-php-cheatsheet) - documents modern (PHP 7.0+) idioms in a unified document.
-* [OWASP Security Cheatsheets](https://www.owasp.org/index.php/OWASP_Cheat_Sheet_Series) - provides a concise collection of high value information on specific application security topics. 
+* [OWASP Security Cheatsheets](https://owasp.org/www-project-cheat-sheets/) - provides a concise collection of high value information on specific application security topics. 
 
 ### More best practices
 

--- a/_posts/16-08-01-Sites.md
+++ b/_posts/16-08-01-Sites.md
@@ -22,7 +22,7 @@ title:   Other Useful Resources
 You can subscribe to weekly newsletters to keep yourself informed on new libraries, latest news, events and general
 announcements, as well as additional resources being published every now and then:
 
-* [PHP Weekly](http://www.phpweekly.com)
+* [PHP Weekly](https://www.phpweekly.com)
 * [JavaScript Weekly](https://javascriptweekly.com/)
 * [Frontend Focus](https://frontendfoc.us/)
 * [Mobile Web Weekly](https://mobiledevweekly.com/)

--- a/_posts/16-10-01-Books.md
+++ b/_posts/16-10-01-Books.md
@@ -21,7 +21,7 @@ for modern, secure, and fast cryptography.
 
 * [Build APIs You Won't Hate](https://apisyouwonthate.com/) - Everyone and their dog wants an API,
 so you should probably learn how to build them.
-* [Modern PHP](http://shop.oreilly.com/product/0636920033868.do) - Covers modern PHP features, best practices, testing, tuning, deployment and setting up a dev environment.
+* [Modern PHP](https://www.oreilly.com/library/view/modern-php/9781491905173/) - Covers modern PHP features, best practices, testing, tuning, deployment and setting up a dev environment.
 * [Building Secure PHP Apps](https://leanpub.com/buildingsecurephpapps) - Learn the security basics that a senior
 developer usually acquires over years of experience, all condensed down into one quick and easy handbook
 * [Modernizing Legacy Applications In PHP](https://leanpub.com/mlaphp) - Get your code under control in a series of


### PR DESCRIPTION
Most of these are trivial.

The Oracle blog change demonstrates why updating redirected links is advisable, as the redirect can disappear over time even while the new path keeps working.
The [archived original](https://web.archive.org/web/20160805222746/https://blogs.oracle.com/opal/entry/php_fpm_fastcgi_process_manager) 6 years ago confirms it's the same article. In 2020 the [old link still redirected](https://web.archive.org/web/20201004085452/https://blogs.oracle.com/opal/entry/php_fpm_fastcgi_process_manager) to the new path, but now it doesn't anymore.

The XAMPP path is another example, it [intermittently redirected](https://web.archive.org/web/20220000000000*/http://www.apachefriends.org/en/xampp.html) to the frontpage as [recently as June](https://web.archive.org/web/20220603155543/https://www.apachefriends.org/en/xampp.html). So updated, without the redundant index.html part.

The old Symfony component link actually redirects to https://github.com/symfony/translation, but the https://symfony.com/translation link there in turn redirects to https://symfony.com/components/Translation, and that looks like the most suitable replacement in the list of components, so I used that instead.