### PR TITLE
Archive jasongrimes.org link

### DIFF
--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -90,7 +90,7 @@ PHP.
 [Ansistrano]: https://ansistrano.com
 [phpdeploy_deployer]: https://www.sitepoint.com/deploying-php-applications-with-deployer/
 [Chef]: https://www.chef.io/
-[chef_vagrant_and_ec2]: http://www.jasongrimes.org/2012/06/managing-lamp-environments-with-chef-vagrant-and-ec2-1-of-3/
+[chef_vagrant_and_ec2]: https://web.archive.org/web/20190307220000/http://www.jasongrimes.org/2012/06/managing-lamp-environments-with-chef-vagrant-and-ec2-1-of-3/
 [Chef_cookbook]: https://github.com/chef-cookbooks/php
 [Chef_tutorial]: https://www.youtube.com/playlist?list=PL11cZfNdwNyPnZA9D1MbVqldGuOWqbumZ
 [apache_ant_tutorial]: https://code.tutsplus.com/tutorials/automate-your-projects-with-apache-ant--net-18595


### PR DESCRIPTION
This is a weird one: the [frontpage](http://www.jasongrimes.org/) still works, probably a static dump. But all subpages result in "Error establishing a database connection". A search on archive.org indicates it died sometime after March 2019.

For an interactive resource (like a GH repo or a PaaS) archived links are meaningless, but for these static blog pages (parts 2 and 3 also work after additional redirects) the Wayback links are a good alternative IMO. Many wiki's use archive.org to keep information accessible.