### PR TITLE
Update links to redirected GH repos

### DIFF
--- a/_posts/05-06-01-Internationalization-and-Localization.md
+++ b/_posts/05-06-01-Internationalization-and-Localization.md
@@ -43,7 +43,7 @@ PHP core, but here we list others for completion:
 - [aura/intl][aura-intl]: Provides internationalization (I18N) tools, specifically package-oriented per-locale message
 translation. It uses array formats for messages. Does not provide a message extractor, but does provide advanced
 message formatting via the `intl` extension (including pluralized messages).
-- [oscarotero/Gettext][oscarotero]: Gettext support with an OO interface; includes improved helper functions, powerful
+- [php-gettext/Gettext][php-gettext]: Gettext support with an OO interface; includes improved helper functions, powerful
 extractors for several file formats (some of them not supported natively by the `gettext` command), and can also export
 to other formats besides `.mo/.po` files. Can be useful if you need to integrate your translation files into other
 parts of the system, like a JavaScript interface.
@@ -373,7 +373,7 @@ As preferred by many people, it is easier to use `_()` instead of `gettext()`. M
 frameworks use something similar to `t()` as well, to make translated code shorter. However, that is the only function
 that sports a shortcut. You might want to add in your project some others, such as `__()` or `_n()` for `ngettext()`,
 or maybe a fancy `_r()` that would join `gettext()` and `sprintf()` calls. Other libraries, such as
-[oscarotero's Gettext][oscarotero] also provide helper functions like these.
+[php-gettext's Gettext][php-gettext] also provide helper functions like these.
 
 In those cases, you'll need to instruct the Gettext utility on how to extract the strings from those new functions.
 Don't be afraid; it is very easy. It is just a field in the `.po` file, or a Settings screen on Poedit. In the editor,
@@ -411,7 +411,7 @@ After including those new rules in the `.po` file, a new scan will bring in your
 [rare]: https://www.gnu.org/software/gettext/manual/gettext.html#Rare-Language-Codes
 [func_format]: https://www.gnu.org/software/gettext/manual/gettext.html#Language-specific-options
 [aura-intl]: https://github.com/auraphp/Aura.Intl
-[oscarotero]: https://github.com/oscarotero/Gettext
+[php-gettext]: https://github.com/php-gettext/Gettext
 [symfony]: https://symfony.com/components/Translation
 [laminas]: https://docs.laminas.dev/laminas-i18n/
 [laravel]: https://laravel.com/docs/master/localization

--- a/_posts/11-02-01-Test-Driven-Development.md
+++ b/_posts/11-02-01-Test-Driven-Development.md
@@ -36,7 +36,7 @@ which accepts pull requests then you should suggest this as a requirement.
 are several alternatives:
 
 * [atoum](https://github.com/atoum/atoum)
-* [Kahlan](https://github.com/crysalead/kahlan)
+* [Kahlan](https://github.com/kahlan/kahlan)
 * [Peridot](https://peridot-php.github.io/)
 * [SimpleTest](https://github.com/simpletest/simpletest)
 

--- a/_posts/12-05-01-Building-your-Application.md
+++ b/_posts/12-05-01-Building-your-Application.md
@@ -91,7 +91,7 @@ PHP.
 [phpdeploy_deployer]: https://www.sitepoint.com/deploying-php-applications-with-deployer/
 [Chef]: https://www.chef.io/
 [chef_vagrant_and_ec2]: https://web.archive.org/web/20190307220000/http://www.jasongrimes.org/2012/06/managing-lamp-environments-with-chef-vagrant-and-ec2-1-of-3/
-[Chef_cookbook]: https://github.com/chef-cookbooks/php
+[Chef_cookbook]: https://github.com/sous-chefs/php
 [Chef_tutorial]: https://www.youtube.com/playlist?list=PL11cZfNdwNyNYcpntVe6js-prb80LBZuc
 [apache_ant_tutorial]: https://code.tutsplus.com/tutorials/automate-your-projects-with-apache-ant--net-18595
 [Travis CI]: https://www.travis-ci.com/


### PR DESCRIPTION
The owners of several GitHub repositories have been renamed, this PR updates their links (and in one case, also the link key).