### PR TITLE
Update Lynda links to LinkedIn

### DIFF
--- a/_posts/03-04-01-Standard-PHP-Library.md
+++ b/_posts/03-04-01-Standard-PHP-Library.md
@@ -11,8 +11,8 @@ primarily of commonly needed datastructure classes (stack, queue, heap, and so o
 over these datastructures or your own classes which implement SPL interfaces.
 
 * [Read about the SPL][spl]
-* [SPL video course on Lynda.com (paid)][spllynda]
+* [SPL video course on LinkedIn.com (paid)][linkedin]
 
 
 [spl]: https://secure.php.net/book.spl
-[spllynda]: https://www.lynda.com/PHP-tutorials/Up-Running-Standard-PHP-Library/175038-2.html
+[linkedin]: https://www.linkedin.com/learning/learning-the-standard-php-library?trk=lynda_redirect_learning

--- a/_posts/16-09-01-Videos.md
+++ b/_posts/16-09-01-Videos.md
@@ -16,6 +16,6 @@ title:   Video Tutorials
 
 * [Standards and Best practices](https://teamtreehouse.com/library/php-standards-and-best-practices)
 * [PHP Training on Pluralsight](https://www.pluralsight.com/search?q=php)
-* [PHP Training on Lynda.com](https://www.lynda.com/search?q=php)
+* [PHP Training on LinkedIn.com](https://www.linkedin.com/learning/search?trk=lynda_redirect_learning&sortBy=RELEVANCE&softwareNames=PHP)
 * [PHP Training on Tutsplus](https://code.tutsplus.com/categories/php/courses)
 * [Laracasts](https://laracasts.com/)


### PR DESCRIPTION
Lynda.com [was acquired](https://news.linkedin.com/2015/linkedin-to-acquire-lyndacom) by LinkedIn in 2015, this PR updates the redirected links accordingly.
Optionally I could remove the 'trk=lynda_redirect_learning' bit, which isn't actually needed?