### PR TITLE
Replace dead sites by GH repos

### DIFF
--- a/_posts/11-02-01-Test-Driven-Development.md
+++ b/_posts/11-02-01-Test-Driven-Development.md
@@ -38,7 +38,7 @@ are several alternatives:
 * [atoum](https://github.com/atoum/atoum)
 * [Kahlan](https://github.com/crysalead/kahlan)
 * [Peridot](https://peridot-php.github.io/)
-* [SimpleTest](http://simpletest.org)
+* [SimpleTest](https://github.com/simpletest/simpletest)
 
 ### Integration Testing
 

--- a/_posts/14-02-01-Opcode-Cache.md
+++ b/_posts/14-02-01-Opcode-Cache.md
@@ -24,7 +24,7 @@ Read more about opcode caches:
 
 [opcache-book]: https://secure.php.net/book.opcache
 [APC]: https://www.php.net/book.apcu
-[XCache]: https://xcache.lighttpd.net/
+[XCache]: https://github.com/lighttpd/xcache
 [Zend Optimizer+]: https://github.com/zendtech/ZendOptimizerPlus
 [WinCache]: https://www.iis.net/downloads/microsoft/wincache-extension
 [PHP_accelerators]: https://wikipedia.org/wiki/List_of_PHP_accelerators


### PR DESCRIPTION
These two sites are 404 not found, but their GitHub repositories are in fine order.
In the second case, the main https://www.lighttpd.net/ site is still active, too, so it's a bit strange the sub-site disappeared.