### PR TITLE
Archive design patterns link & add PDF (fixes #935)

### DIFF
--- a/_posts/05-04-01-Design-Patterns.md
+++ b/_posts/05-04-01-Design-Patterns.md
@@ -16,4 +16,4 @@ then you have to find the patterns that best suit the type and size of applicati
 
 You can learn more about PHP design patterns and see working examples at:
 
-<https://designpatternsphp.readthedocs.io/>
+[https://designpatternsphp.readthedocs.io/](https://web.archive.org/web/20221007015016/https://designpatternsphp.readthedocs.io/en/latest/README.html) (archived, [PDF download](https://www.computer-pdf.com/web-programming/php/924-tutorial-designpatternsphp-documentation.html))


### PR DESCRIPTION
The site was dismantled and I didn't find a suitable replacement, hence the archive link. Also added a suitable PDF download link.

There is a similar site at https://refactoring.guru/design-patterns/php which may also be suitable for inclusion?