### PR TITLE
Archive two broken links

### DIFF
--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -75,7 +75,7 @@ you and tie them all together, but ease of setup comes with a trade-off of flexi
 [Homebrew PHP]: https://github.com/Homebrew/homebrew-php#installation
 [MacPorts]: https://www.macports.org/install.php
 [phpbrew]: https://github.com/phpbrew/phpbrew
-[php-osx.liip.ch]: https://php-osx.liip.ch/
+[php-osx.liip.ch]: https://web.archive.org/web/20220505163210/https://php-osx.liip.ch/
 [mac-compile]: https://secure.php.net/install.macosx.compile
 [xcode-gcc-substitution]: https://github.com/kennethreitz/osx-gcc-installer
 ["Command Line Tools for XCode"]: https://developer.apple.com/downloads

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -31,4 +31,4 @@ Chris Tankersley has a very helpful blog post on what tools he uses to do [PHP d
 [php-iis]: https://php.iis.net/
 [windows-path]: https://www.windows-commandline.com/set-path-command-line/
 [windows-tools]: https://ctankersley.com/2016/11/13/developing-on-windows-2016/
-[xampp]: http://www.apachefriends.org/
+[xampp]: https://www.apachefriends.org/

--- a/_posts/07-03-01-Databases_PDO.md
+++ b/_posts/07-03-01-Databases_PDO.md
@@ -72,6 +72,6 @@ unless of course you are using persistent connections.
 
 
 [pdo]: https://secure.php.net/pdo
-[SQL Injection]: http://wiki.hashphp.org/Validation
+[SQL Injection]: https://web.archive.org/web/20210413233627/http://wiki.hashphp.org/Validation
 [Learn about PDO]: https://secure.php.net/book.pdo
 [Learn about PDO connections]: https://secure.php.net/pdo.connections


### PR DESCRIPTION
php-osx.liip.ch's certificate expired on June 22. Since its content is marked deprecated anyway, an archive link seems a suitable replacement.

wiki.hashphp.org is online, though without style sheet and database, so the Validation link errors out. Here too the archive link keeps the info accessible.

Subjecting this to review because I'm not sure what, if any, policy there is for archiving these types of links.

Also adds a https redirect overlooked for 14954aa.