### PR TITLE
docs: replace current stable version of php 8.1 = 8.1

### DIFF
--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -6,10 +6,12 @@ anchor:  use_the_current_stable_version
 
 ## Use the Current Stable Version (8.2) {#use_the_current_stable_version_title}
 
-If you are getting started with PHP, start with the current stable release of [PHP 8.2][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x and 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8 is a major update of the language and contains many new features and optimizations.
+If you are getting started with PHP, start with the current stable release of [PHP 8.2][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x aä#Vnfcd 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8 is a major update of the language and contains many new features and optimizations.
 
-You should try to upgrade to the latest stable version quickly - PHP 7.4 [is already End of Life](http://php.net/supported-versions.php). Upgrading is easy, as there are not many [backwards compatibility breaks][php-bc]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
+You should try to upgrade to the latest stable version quickly - PHP 7.4 [is already End of Life](http://php.net/supported-versions.php). Upgrading is easy, as there are not many backwards compatibility breaks [PHP 8.0][php-bc-80], [PHP 8.1][php-bc-81], [PHP 8.2][php-bc-82]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
 
 [php-release]: https://php.net/downloads.php
 [php-docs]: https://php.net/manual/
-[php-bc]: https://php.net/manual/migration82.incompatible.php
+[php-bc-80]: https://php.net/manual/migration80.incompatible.php
+[php-bc-81]: https://php.net/manual/migration81.incompatible.php
+[php-bc-82]: https://php.net/manual/migration82.incompatible.php

--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -6,7 +6,7 @@ anchor:  use_the_current_stable_version
 
 ## Use the Current Stable Version (8.2) {#use_the_current_stable_version_title}
 
-If you are getting started with PHP, start with the current stable release of [PHP 8.2][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x aä#Vnfcd 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8 is a major update of the language and contains many new features and optimizations.
+If you are getting started with PHP, start with the current stable release of [PHP 8.2][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x and 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8 is a major update of the language and contains many new features and optimizations.
 
 You should try to upgrade to the latest stable version quickly - PHP 7.4 [is already End of Life](http://php.net/supported-versions.php). Upgrading is easy, as there are not many backwards compatibility breaks [PHP 8.0][php-bc-80], [PHP 8.1][php-bc-81], [PHP 8.2][php-bc-82]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
 

--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -1,15 +1,15 @@
 ---
-title:   Use the Current Stable Version (8.1)
+title:   Use the Current Stable Version (8.2)
 isChild: true
 anchor:  use_the_current_stable_version
 ---
 
-## Use the Current Stable Version (8.1) {#use_the_current_stable_version_title}
+## Use the Current Stable Version (8.2) {#use_the_current_stable_version_title}
 
-If you are getting started with PHP, start with the current stable release of [PHP 8.1][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x and 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8 is a major update of the language and contains many new features and optimizations.
+If you are getting started with PHP, start with the current stable release of [PHP 8.2][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x and 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8 is a major update of the language and contains many new features and optimizations.
 
 You should try to upgrade to the latest stable version quickly - PHP 7.4 [is already End of Life](http://php.net/supported-versions.php). Upgrading is easy, as there are not many [backwards compatibility breaks][php-bc]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
 
-[php-release]: http://php.net/downloads.php
-[php-docs]: http://php.net/manual/
-[php-bc]: http://php.net/manual/migration81.incompatible.php
+[php-release]: https://php.net/downloads.php
+[php-docs]: https://php.net/manual/
+[php-bc]: https://php.net/manual/migration82.incompatible.php

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -9,10 +9,10 @@ macOS comes prepackaged with PHP but it is normally a little behind the latest s
 
 ### Install PHP via Homebrew
 
-[Homebrew] is a package manager for macOS that helps you easily install PHP and various extensions. The Homebrew core repository provides "formulae" for PHP 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0 and PHP 8.1. Install the latest version with this command:
+[Homebrew] is a package manager for macOS that helps you easily install PHP and various extensions. The Homebrew core repository provides "formulae" for PHP 7.4, 8.0, 8.1 and PHP 8.2. Install the latest version with this command:
 
 ```
-brew install php@8.1
+brew install php@8.2
 ```
 
 You can switch between Homebrew PHP versions by modifying your `PATH` variable. Alternatively, you can use [brew-php-switcher][brew-php-switcher] to switch PHP versions automatically.
@@ -21,12 +21,12 @@ You can also switch between PHP versions manually by unlinking and linking the w
 
 ```
 brew unlink php
-brew link --overwrite php@8.0
+brew link --overwrite php@8.1
 ```
 
 ```
 brew unlink php
-brew link --overwrite php@8.1
+brew link --overwrite php@8.2
 ```
 
 ### Install PHP via Macports
@@ -40,14 +40,14 @@ MacPorts supports pre-compiled binaries, so you don't need to recompile every
 dependency from the source tarball files, it saves your life if you don't
 have any package installed on your system.
 
-At this point, you can install `php54`, `php55`, `php56`, `php70`, `php71`, `php72`, `php73`, `php74`, `php80` or `php81` using the `port install` command, for example:
+At this point, you can install `php54`, `php55`, `php56`, `php70`, `php71`, `php72`, `php73`, `php74`, `php80`, `php81`  or `php82` using the `port install` command, for example:
 
     sudo port install php74
-    sudo port install php81
+    sudo port install php82
 
 And you can run `select` command to switch your active PHP:
 
-    sudo port select --set php php81
+    sudo port select --set php php82
 
 ### Install PHP via phpbrew
 


### PR DESCRIPTION
homebrew only allows support for php >=  7.4
https://formulae.brew.sh/formula/php#default

Maybe the outdated version of macports could be removed too.
`php54`, `php55`, `php56`, `php70`, `php71`, `php72`, `php73`, `php74`,


By the way i really enjoyed the book. It motivates me to progamm with php. Thanks