### PR TITLE
Remove XCache

### DIFF
--- a/_posts/14-02-01-Opcode-Cache.md
+++ b/_posts/14-02-01-Opcode-Cache.md
@@ -16,7 +16,6 @@ Read more about opcode caches:
 * [Zend OPcache][opcache-book] (bundled with PHP since 5.5)
 * Zend OPcache (formerly known as Zend Optimizer+) is now [open source][Zend Optimizer+]
 * [APC] - PHP 5.4 and earlier
-* [XCache]
 * [WinCache] (extension for MS Windows Server)
 * [list of PHP accelerators on Wikipedia][PHP_accelerators]
 * [PHP Preloading] - PHP >= 7.4
@@ -24,7 +23,6 @@ Read more about opcode caches:
 
 [opcache-book]: https://secure.php.net/book.opcache
 [APC]: https://www.php.net/book.apcu
-[XCache]: https://github.com/lighttpd/xcache
 [Zend Optimizer+]: https://github.com/zendtech/ZendOptimizerPlus
 [WinCache]: https://www.iis.net/downloads/microsoft/wincache-extension
 [PHP_accelerators]: https://wikipedia.org/wiki/List_of_PHP_accelerators

--- a/_posts/14-03-01-Object-Caching.md
+++ b/_posts/14-03-01-Object-Caching.md
@@ -12,7 +12,7 @@ them, then pull them directly from the cache for following requests, you can gai
 performance as well as reduce the load on your database servers.
 
 Many of the popular bytecode caching solutions let you cache custom data as well, so there's even more reason to take
-advantage of them. APCu, XCache, and WinCache all provide APIs to save data from your PHP code to their memory cache.
+advantage of them. APCu and WinCache both provide APIs to save data from your PHP code to their memory cache.
 
 The most commonly used memory object caching systems are APCu and memcached. APCu is an excellent choice for object
 caching, it includes a simple API for adding your own data to its memory cache and is very easy to setup and use. The
@@ -51,5 +51,4 @@ object cache to PHP 5.5+, since PHP now has a built-in bytecode cache (OPcache).
 * [APC Functions](https://secure.php.net/ref.apc)
 * [Memcached](https://memcached.org/)
 * [Redis](https://redis.io/)
-* [XCache APIs](https://xcache.lighttpd.net/wiki/XcacheApi)
 * [WinCache Functions](https://secure.php.net/ref.wincache)


### PR DESCRIPTION
XCache integration made sense with PHP 5.6 and older versions. With OPCache being available directly in the PHP it made less sense to enable it as well. Also the upstream site doesn't seem to be maintained anymore.