### PR TITLE
Remove scream PHP extension

### DIFF
--- a/_posts/09-02-01-Errors.md
+++ b/_posts/09-02-01-Errors.md
@@ -112,19 +112,13 @@ You can also set this value at runtime with the `ini_set` function
 ini_set('xdebug.scream', '1')
 {% endhighlight %}
 
-The "[Scream]" PHP extension offers similar functionality to Xdebug's, although Scream's ini setting is named
-`scream.enabled`.
-
 This is most useful when you're debugging code and suspect an informative error is suppressed. Use scream with care,
 and as a temporary debugging tool. There's lots of PHP library code that may not work with the error control operator
 disabled.
 
-
 * [Error Control Operators]
 * [SitePoint]
 * [Xdebug]
-* [Scream]
-
 
 ### ErrorException
 
@@ -152,7 +146,6 @@ More information on this and details on how to use `ErrorException` with error h
 
 [errorreport]: /#error_reporting
 [Xdebug]: https://xdebug.org/docs/basic
-[Scream]: https://secure.php.net/book.scream
 [Error Control Operators]: https://secure.php.net/language.operators.errorcontrol
 [SitePoint]: https://www.sitepoint.com/
 [Whoops!]: https://filp.github.io/whoops/


### PR DESCRIPTION
The scream PHP extension has been removed from the documentation and its PECL package is unmaintaned.