### PR TITLE
Update APC and APCu

### DIFF
--- a/_posts/14-02-01-Opcode-Cache.md
+++ b/_posts/14-02-01-Opcode-Cache.md
@@ -15,14 +15,12 @@ Read more about opcode caches:
 
 * [Zend OPcache][opcache-book] (bundled with PHP since 5.5)
 * Zend OPcache (formerly known as Zend Optimizer+) is now [open source][Zend Optimizer+]
-* [APC] - PHP 5.4 and earlier
 * [WinCache] (extension for MS Windows Server)
 * [list of PHP accelerators on Wikipedia][PHP_accelerators]
 * [PHP Preloading] - PHP >= 7.4
 
 
 [opcache-book]: https://secure.php.net/book.opcache
-[APC]: https://www.php.net/book.apcu
 [Zend Optimizer+]: https://github.com/zendtech/ZendOptimizerPlus
 [WinCache]: https://www.iis.net/downloads/microsoft/wincache-extension
 [PHP_accelerators]: https://wikipedia.org/wiki/List_of_PHP_accelerators

--- a/_posts/14-03-01-Object-Caching.md
+++ b/_posts/14-03-01-Object-Caching.md
@@ -42,7 +42,7 @@ if ($data === false) {
 print_r($data);
 {% endhighlight %}
 
-Note that prior to PHP 5.5, there was APC extension which provided both an object cache and a bytecode cache. The new APCu is a project to bring APC's
+Note that prior to PHP 5.5, there was the APC extension which provided both an object cache and a bytecode cache. The new APCu is a project to bring APC's
 object cache to PHP 5.5+, since PHP now has a built-in bytecode cache (OPcache).
 
 ### Learn more about popular object caching systems:

--- a/_posts/14-03-01-Object-Caching.md
+++ b/_posts/14-03-01-Object-Caching.md
@@ -33,22 +33,22 @@ Example logic using APCu:
 {% highlight php %}
 <?php
 // check if there is data saved as 'expensive_data' in cache
-$data = apc_fetch('expensive_data');
+$data = apcu_fetch('expensive_data');
 if ($data === false) {
     // data is not in cache; save result of expensive call for later use
-    apc_add('expensive_data', $data = get_expensive_data());
+    apcu_add('expensive_data', $data = get_expensive_data());
 }
 
 print_r($data);
 {% endhighlight %}
 
-Note that prior to PHP 5.5, APC provides both an object cache and a bytecode cache. APCu is a project to bring APC's
+Note that prior to PHP 5.5, there was APC extension which provided both an object cache and a bytecode cache. The new APCu is a project to bring APC's
 object cache to PHP 5.5+, since PHP now has a built-in bytecode cache (OPcache).
 
 ### Learn more about popular object caching systems:
 
 * [APCu](https://github.com/krakjoe/apcu)
-* [APC Functions](https://secure.php.net/ref.apc)
+* [APCu Documentation](https://www.php.net/apcu)
 * [Memcached](https://memcached.org/)
 * [Redis](https://redis.io/)
 * [WinCache Functions](https://secure.php.net/ref.wincache)


### PR DESCRIPTION
The maintained APCu extension is the previous APC extension without opcode caching. APC is as of this writing unmaintained.