### PR TITLE
Remove 404 register globals PHP link

### DIFF
--- a/_posts/10-06-01-Register-Globals.md
+++ b/_posts/10-06-01-Register-Globals.md
@@ -15,5 +15,3 @@ issues as your application cannot effectively tell where the data is coming from
 For example: `$_GET['foo']` would be available via `$foo`, which can override variables that have been declared.
 
 If you are using PHP < 5.4.0 __make sure__ that `register_globals` is __off__.
-
-* [Register_globals in the PHP manual](https://secure.php.net/security.globals)


### PR DESCRIPTION
The PHP manual page about register_globals directive has been removed in the PHP manual.
https://github.com/php/doc-en/pull/327
