### PR TITLE
Update php.net links to point to https://www.php.net

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,4 +116,4 @@ All content is completely free now, and always will be.
 3. Wrap all text to 120 characters
 4. Code samples should adhere to PSR-1 or higher
 5. Use [GitHub Flavored Markdown](https://github.github.com/gfm/) for all content
-6. Use language agnostic urls when referring to external websites such as the [php.net](http://php.net/urlhowto.php) manual
+6. Use language agnostic urls when referring to external websites such as the [php.net](https://www.php.net/urlhowto.php) manual

--- a/_posts/01-02-01-Use-the-Current-Stable-Version.md
+++ b/_posts/01-02-01-Use-the-Current-Stable-Version.md
@@ -8,10 +8,11 @@ anchor:  use_the_current_stable_version
 
 If you are getting started with PHP, start with the current stable release of [PHP 8.2][php-release]. PHP 8.x adds many [new features](#language_highlights) over the older 7.x and 5.x versions. The engine has been largely re-written, and PHP is now even quicker than older versions. PHP 8 is a major update of the language and contains many new features and optimizations.
 
-You should try to upgrade to the latest stable version quickly - PHP 7.4 [is already End of Life](http://php.net/supported-versions.php). Upgrading is easy, as there are not many backwards compatibility breaks [PHP 8.0][php-bc-80], [PHP 8.1][php-bc-81], [PHP 8.2][php-bc-82]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
+You should try to upgrade to the latest stable version quickly - PHP 7.4 [is already End of Life][php-supported]. Upgrading is easy, as there are not many backwards compatibility breaks [PHP 8.0][php-bc-80], [PHP 8.1][php-bc-81], [PHP 8.2][php-bc-82]. If you are not sure which version a function or feature is in, you can check the PHP documentation on the [php.net][php-docs] website.
 
-[php-release]: https://php.net/downloads.php
-[php-docs]: https://php.net/manual/
-[php-bc-80]: https://php.net/manual/migration80.incompatible.php
-[php-bc-81]: https://php.net/manual/migration81.incompatible.php
-[php-bc-82]: https://php.net/manual/migration82.incompatible.php
+[php-release]: https://www.php.net/downloads.php
+[php-supported]: https://www.php.net/supported-versions.php
+[php-docs]: https://www.php.net/manual/
+[php-bc-80]: https://www.php.net/manual/migration80.incompatible.php
+[php-bc-81]: https://www.php.net/manual/migration81.incompatible.php
+[php-bc-82]: https://www.php.net/manual/migration82.incompatible.php

--- a/_posts/01-03-01-Built-in-Web-Server.md
+++ b/_posts/01-03-01-Built-in-Web-Server.md
@@ -16,4 +16,4 @@ To start the server, run the following command from your terminal in your projec
 * [Learn about the built-in, command line web server][cli-server]
 
 
-[cli-server]: http://php.net/features.commandline.webserver
+[cli-server]: https://www.php.net/features.commandline.webserver

--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -76,7 +76,7 @@ you and tie them all together, but ease of setup comes with a trade-off of flexi
 [MacPorts]: https://www.macports.org/install.php
 [phpbrew]: https://github.com/phpbrew/phpbrew
 [php-osx.liip.ch]: https://web.archive.org/web/20220505163210/https://php-osx.liip.ch/
-[mac-compile]: https://secure.php.net/install.macosx.compile
+[mac-compile]: https://www.php.net/install.macosx.compile
 [xcode-gcc-substitution]: https://github.com/kennethreitz/osx-gcc-installer
 ["Command Line Tools for XCode"]: https://developer.apple.com/downloads
 [apache]: https://httpd.apache.org/

--- a/_posts/03-02-01-Programming-Paradigms.md
+++ b/_posts/03-02-01-Programming-Paradigms.md
@@ -50,14 +50,13 @@ available as `__call()` and `__callStatic()`.
 * [Read about Overloading][overloading]
 
 
-[oop]: https://secure.php.net/language.oop5
-[traits]: https://secure.php.net/language.oop5.traits
-[anonymous-functions]: https://secure.php.net/functions.anonymous
-[closure-class]: https://secure.php.net/class.closure
+[oop]: https://www.php.net/language.oop5
+[traits]: https://www.php.net/language.oop5.traits
+[anonymous-functions]: https://www.php.net/functions.anonymous
+[closure-class]: https://www.php.net/class.closure
 [closures-rfc]: https://wiki.php.net/rfc/closures
-[callables]: https://secure.php.net/language.types.callable
-[call-user-func-array]: https://secure.php.net/function.call-user-func-array
-[magic-methods]: https://secure.php.net/language.oop5.magic
-[reflection]: https://secure.php.net/intro.reflection
-[overloading]: https://secure.php.net/language.oop5.overloading
-
+[callables]: https://www.php.net/language.types.callable
+[call-user-func-array]: https://www.php.net/function.call-user-func-array
+[magic-methods]: https://www.php.net/language.oop5.magic
+[reflection]: https://www.php.net/intro.reflection
+[overloading]: https://www.php.net/language.oop5.overloading

--- a/_posts/03-03-01-Namespaces.md
+++ b/_posts/03-03-01-Namespaces.md
@@ -28,6 +28,6 @@ If you're going to use an autoloader standard for a new application or package, 
 * [Read about PSR-4][psr4]
 
 
-[namespaces]: https://secure.php.net/language.namespaces
+[namespaces]: https://www.php.net/language.namespaces
 [psr0]: https://www.php-fig.org/psr/psr-0/
 [psr4]: https://www.php-fig.org/psr/psr-4/

--- a/_posts/03-04-01-Standard-PHP-Library.md
+++ b/_posts/03-04-01-Standard-PHP-Library.md
@@ -14,5 +14,5 @@ over these datastructures or your own classes which implement SPL interfaces.
 * [SPL video course on LinkedIn.com (paid)][linkedin]
 
 
-[spl]: https://secure.php.net/book.spl
+[spl]: https://www.php.net/book.spl
 [linkedin]: https://www.linkedin.com/learning/learning-the-standard-php-library?trk=lynda_redirect_learning

--- a/_posts/03-05-01-Command-Line-Interface.md
+++ b/_posts/03-05-01-Command-Line-Interface.md
@@ -53,9 +53,9 @@ Hello, world
 
  * [Learn about running PHP from the command line][php-cli]
 
-[phpinfo]: https://secure.php.net/function.phpinfo
-[cli-options]: https://secure.php.net/features.commandline.options
-[argc]: https://secure.php.net/reserved.variables.argc
-[argv]: https://secure.php.net/reserved.variables.argv
+[phpinfo]: https://www.php.net/function.phpinfo
+[cli-options]: https://www.php.net/features.commandline.options
+[argc]: https://www.php.net/reserved.variables.argc
+[argv]: https://www.php.net/reserved.variables.argv
 [exit-codes]: https://www.gsp.com/cgi-bin/man.cgi?section=3&amp;topic=sysexits
-[php-cli]: https://secure.php.net/features.commandline.options
+[php-cli]: https://www.php.net/manual/en/features.commandline.php

--- a/_posts/05-03-01-Date-and-Time.md
+++ b/_posts/05-03-01-Date-and-Time.md
@@ -65,5 +65,5 @@ A popular PHP API extension is [Carbon](https://carbon.nesbot.com/). It inherits
 * [Read about DateTime][datetime]
 * [Read about date formatting][dateformat] (accepted date format string options)
 
-[datetime]: https://secure.php.net/book.datetime
-[dateformat]: https://secure.php.net/function.date
+[datetime]: https://www.php.net/book.datetime
+[dateformat]: https://www.php.net/function.date

--- a/_posts/05-05-01-PHP-and-UTF8.md
+++ b/_posts/05-05-01-PHP-and-UTF8.md
@@ -44,7 +44,7 @@ Finally, If you are building a distributed application and cannot be certain tha
 enabled, then consider using the [symfony/polyfill-mbstring] Composer package. This will use `mbstring` if it is available, and
 fall back to non UTF-8 functions if not.
 
-[Multibyte String Extension]: https://secure.php.net/book.mbstring
+[Multibyte String Extension]: https://www.php.net/book.mbstring
 [symfony/polyfill-mbstring]: https://packagist.org/packages/symfony/polyfill-mbstring
 
 ### UTF-8 at the Database level
@@ -146,19 +146,19 @@ header('Content-Type: text/html; charset=UTF-8'); // Unnecessary if your default
 
 ### Further reading
 
-* [PHP Manual: String Operations](https://secure.php.net/language.operators.string)
-* [PHP Manual: String Functions](https://secure.php.net/ref.strings)
-    * [`strpos()`](https://secure.php.net/function.strpos)
-    * [`strlen()`](https://secure.php.net/function.strlen)
-    * [`substr()`](https://secure.php.net/function.substr)
-* [PHP Manual: Multibyte String Functions](https://secure.php.net/ref.mbstring)
-    * [`mb_strpos()`](https://secure.php.net/function.mb-strpos)
-    * [`mb_strlen()`](https://secure.php.net/function.mb-strlen)
-    * [`mb_substr()`](https://secure.php.net/function.mb-substr)
-    * [`mb_internal_encoding()`](https://secure.php.net/function.mb-internal-encoding)
-    * [`mb_http_output()`](https://secure.php.net/function.mb-http-output)
-    * [`htmlentities()`](https://secure.php.net/function.htmlentities)
-    * [`htmlspecialchars()`](https://secure.php.net/function.htmlspecialchars)
+* [PHP Manual: String Operations](https://www.php.net/language.operators.string)
+* [PHP Manual: String Functions](https://www.php.net/ref.strings)
+    * [`strpos()`](https://www.php.net/function.strpos)
+    * [`strlen()`](https://www.php.net/function.strlen)
+    * [`substr()`](https://www.php.net/function.substr)
+* [PHP Manual: Multibyte String Functions](https://www.php.net/ref.mbstring)
+    * [`mb_strpos()`](https://www.php.net/function.mb-strpos)
+    * [`mb_strlen()`](https://www.php.net/function.mb-strlen)
+    * [`mb_substr()`](https://www.php.net/function.mb-substr)
+    * [`mb_internal_encoding()`](https://www.php.net/function.mb-internal-encoding)
+    * [`mb_http_output()`](https://www.php.net/function.mb-http-output)
+    * [`htmlentities()`](https://www.php.net/function.htmlentities)
+    * [`htmlspecialchars()`](https://www.php.net/function.htmlspecialchars)
 * [Stack Overflow: What factors make PHP Unicode-incompatible?](https://stackoverflow.com/questions/571694/what-factors-make-php-unicode-incompatible)
 * [Stack Overflow: Best practices in PHP and MySQL with international strings](https://stackoverflow.com/questions/140728/best-practices-in-php-and-mysql-with-international-strings)
 * [How to support full Unicode in MySQL databases](https://mathiasbynens.be/notes/mysql-utf8mb4)

--- a/_posts/05-06-01-Internationalization-and-Localization.md
+++ b/_posts/05-06-01-Internationalization-and-Localization.md
@@ -396,7 +396,7 @@ After including those new rules in the `.po` file, a new scan will bring in your
 * [Wikipedia: i18n and l10n](https://en.wikipedia.org/wiki/Internationalization_and_localization)
 * [Wikipedia: Gettext](https://en.wikipedia.org/wiki/Gettext)
 * [LingoHub: PHP internationalization with gettext tutorial][lingohub]
-* [PHP Manual: Gettext](https://secure.php.net/manual/book.gettext.php)
+* [PHP Manual: Gettext](https://www.php.net/manual/book.gettext.php)
 * [Gettext Manual][manual]
 
 [Poedit]: https://poedit.net
@@ -416,12 +416,12 @@ After including those new rules in the `.po` file, a new scan will bring in your
 [laminas]: https://docs.laminas.dev/laminas-i18n/
 [laravel]: https://laravel.com/docs/master/localization
 [yii]: https://www.yiiframework.com/doc/guide/2.0/en/tutorial-i18n
-[intl]: https://secure.php.net/manual/intro.intl.php
+[intl]: https://www.php.net/manual/intro.intl.php
 [ICU project]: https://icu.unicode.org/
 [symfony-keys]: https://symfony.com/doc/current/translation.html#using-real-or-keyword-messages
 
-[sprintf]: https://secure.php.net/manual/function.sprintf.php
-[func]: https://secure.php.net/manual/function.gettext.php
-[n_func]: https://secure.php.net/manual/function.ngettext.php
-[d_func]: https://secure.php.net/manual/function.dgettext.php
-[dn_func]: https://secure.php.net/manual/function.dngettext.php
+[sprintf]: https://www.php.net/manual/function.sprintf.php
+[func]: https://www.php.net/manual/function.gettext.php
+[n_func]: https://www.php.net/manual/function.ngettext.php
+[d_func]: https://www.php.net/manual/function.dgettext.php
+[dn_func]: https://www.php.net/manual/function.dngettext.php

--- a/_posts/07-01-01-Databases.md
+++ b/_posts/07-01-01-Databases.md
@@ -14,6 +14,6 @@ MySQL and a little bit of MSSQL, or you need to connect to an Oracle database, t
 same drivers. You'll need to learn a brand new API for each database &mdash; and that can get silly.
 
 
-[mysqli]: https://secure.php.net/mysqli
-[pgsql]: https://secure.php.net/pgsql
-[mssql]: https://secure.php.net/mssql
+[mysqli]: https://www.php.net/mysqli
+[pgsql]: https://www.php.net/pgsql
+[mssql]: https://www.php.net/mssql

--- a/_posts/07-02-01-Databases_MySQL.md
+++ b/_posts/07-02-01-Databases_MySQL.md
@@ -27,10 +27,10 @@ your applications within your own development schedules so you won't be rushed l
 * [MySQLi Prepared Statements][mysqli_prepared_statements]
 * [PHP: Choosing an API for MySQL][mysql_api]
 
-[mysql]: https://secure.php.net/mysqli
-[mysql_deprecated]: https://secure.php.net/migration55.deprecated
-[mysql_removed]: https://secure.php.net/manual/migration70.removed-exts-sapis.php
-[mysqli]: https://secure.php.net/mysqli
-[pdo]: https://secure.php.net/pdo
-[mysql_api]: https://secure.php.net/mysqlinfo.api.choosing
+[mysql]: https://www.php.net/mysqli
+[mysql_deprecated]: https://www.php.net/migration55.deprecated
+[mysql_removed]: https://www.php.net/manual/migration70.removed-exts-sapis.php
+[mysqli]: https://www.php.net/mysqli
+[pdo]: https://www.php.net/pdo
+[mysql_api]: https://www.php.net/mysqlinfo.api.choosing
 [mysqli_prepared_statements]: https://websitebeaver.com/prepared-statements-in-php-mysqli-to-prevent-sql-injection

--- a/_posts/07-03-01-Databases_PDO.md
+++ b/_posts/07-03-01-Databases_PDO.md
@@ -60,7 +60,7 @@ introduced to the database preventing potential SQL injection attacks.
 
 For writes, such as INSERT or UPDATE, it's especially critical to still [filter your data](#data_filtering) first and sanitize it for other things (removal of HTML tags, JavaScript, etc).  PDO will only sanitize it for SQL, not for your application.
 
-* [Learn about PDO]
+* [Learn about PDO][pdo]
 
 You should also be aware that database connections use up resources and it was not unheard-of to have resources
 exhausted if connections were not implicitly closed, however this was more common in other languages. Using PDO you can
@@ -71,7 +71,6 @@ unless of course you are using persistent connections.
 * [Learn about PDO connections]
 
 
-[pdo]: https://secure.php.net/pdo
+[pdo]: https://www.php.net/pdo
 [SQL Injection]: https://web.archive.org/web/20210413233627/http://wiki.hashphp.org/Validation
-[Learn about PDO]: https://secure.php.net/book.pdo
-[Learn about PDO connections]: https://secure.php.net/pdo.connections
+[Learn about PDO connections]: https://www.php.net/pdo.connections

--- a/_posts/07-05-01-Abstraction-Layers.md
+++ b/_posts/07-05-01-Abstraction-Layers.md
@@ -23,7 +23,7 @@ installed in any application you like:
 * [Zend-db][4]
 
 
-[1]: https://secure.php.net/book.pdo
+[1]: https://www.php.net/book.pdo
 [2]: https://www.doctrine-project.org/projects/dbal.html
 [4]: https://packages.zendframework.com/docs/latest/manual/en/index.html#zendframework/zend-db
 [5]: https://atlasphp.io

--- a/_posts/09-02-01-Errors.md
+++ b/_posts/09-02-01-Errors.md
@@ -146,9 +146,9 @@ More information on this and details on how to use `ErrorException` with error h
 
 [errorreport]: /#error_reporting
 [Xdebug]: https://xdebug.org/docs/basic
-[Error Control Operators]: https://secure.php.net/language.operators.errorcontrol
+[Error Control Operators]: https://www.php.net/language.operators.errorcontrol
 [SitePoint]: https://www.sitepoint.com/
 [Whoops!]: https://filp.github.io/whoops/
-[errorexception]: https://secure.php.net/class.errorexception
-[Predefined Constants for Error Handling]: https://secure.php.net/errorfunc.constants
-[error_reporting]: https://secure.php.net/function.error-reporting
+[errorexception]: https://www.php.net/class.errorexception
+[Predefined Constants for Error Handling]: https://www.php.net/errorfunc.constants
+[error_reporting]: https://www.php.net/function.error-reporting

--- a/_posts/09-03-01-Exceptions.md
+++ b/_posts/09-03-01-Exceptions.md
@@ -70,6 +70,6 @@ standard Exception which is vague, or creating a custom Exception just for that,
 
 
 [splext]: /#standard_php_library
-[exceptions]: https://secure.php.net/language.exceptions
-[splexe]: https://secure.php.net/spl.exceptions
+[exceptions]: https://www.php.net/language.exceptions
+[splexe]: https://www.php.net/spl.exceptions
 [nesting-exceptions-in-php]: https://www.brandonsavage.net/exceptional-php-nesting-exceptions-in-php/

--- a/_posts/10-03-01-Password-Hashing.md
+++ b/_posts/10-03-01-Password-Hashing.md
@@ -65,7 +65,7 @@ if (password_verify('bad-password', $passwordHash)) {
 * [PHP `password_hash()` RFC] [4]
 
 
-[1]: https://secure.php.net/function.password-hash
+[1]: https://www.php.net/function.password-hash
 [2]: https://github.com/ircmaxell/password_compat
 [3]: https://wikipedia.org/wiki/Cryptographic_hash_function
 [4]: https://wiki.php.net/rfc/password_hash

--- a/_posts/10-04-01-Data-Filtering.md
+++ b/_posts/10-04-01-Data-Filtering.md
@@ -62,11 +62,11 @@ phone number, or age when processing a registration submission.
 [See Validation Filters][3]
 
 
-[1]: https://secure.php.net/book.filter
-[2]: https://secure.php.net/filter.filters.sanitize
-[3]: https://secure.php.net/filter.filters.validate
-[4]: https://secure.php.net/function.filter-var
-[5]: https://secure.php.net/function.filter-input
-[6]: https://secure.php.net/security.filesystem.nullbytes
+[1]: https://www.php.net/book.filter
+[2]: https://www.php.net/filter.filters.sanitize
+[3]: https://www.php.net/filter.filters.validate
+[4]: https://www.php.net/function.filter-var
+[5]: https://www.php.net/function.filter-input
+[6]: https://www.php.net/security.filesystem.nullbytes
 [html-purifier]: http://htmlpurifier.org/
-[unserialize]: https://secure.php.net/manual/function.unserialize.php
+[unserialize]: https://www.php.net/manual/function.unserialize.php

--- a/_posts/10-07-01-Error-Reporting.md
+++ b/_posts/10-07-01-Error-Reporting.md
@@ -23,7 +23,7 @@ log_errors = On
 
 > Passing in the value `-1` will show every possible error, even when new levels and constants are added in future PHP
 > versions. The `E_ALL` constant also behaves this way as of PHP 5.4. -
-> [php.net](https://secure.php.net/function.error-reporting)
+> [php.net](https://www.php.net/function.error-reporting)
 
 The `E_STRICT` error level constant was introduced in 5.3.0 and is not part of `E_ALL`, however it became part of
 `E_ALL` in 5.4.0. What does this mean? In terms of reporting every possible error in version 5.3 it means you must
@@ -49,7 +49,7 @@ log_errors = On
 With these settings in production, errors will still be logged to the error logs for the web server, but will not be
 shown to the user. For more information on these settings, see the PHP manual:
 
-* [error_reporting](https://secure.php.net/errorfunc.configuration#ini.error-reporting)
-* [display_errors](https://secure.php.net/errorfunc.configuration#ini.display-errors)
-* [display_startup_errors](https://secure.php.net/errorfunc.configuration#ini.display-startup-errors)
-* [log_errors](https://secure.php.net/errorfunc.configuration#ini.log-errors)
+* [error_reporting](https://www.php.net/errorfunc.configuration#ini.error-reporting)
+* [display_errors](https://www.php.net/errorfunc.configuration#ini.display-errors)
+* [display_startup_errors](https://www.php.net/errorfunc.configuration#ini.display-startup-errors)
+* [log_errors](https://www.php.net/errorfunc.configuration#ini.log-errors)

--- a/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
+++ b/_posts/12-03-01-Virtual-or-Dedicated-Servers.md
@@ -46,7 +46,7 @@ If you are running Apache 2.4 or later, you can use [mod_proxy_fcgi] to get grea
 
 
 [nginx]: https://nginx.org/
-[phpfpm]: https://secure.php.net/install.fpm
+[phpfpm]: https://www.php.net/install.fpm
 [secure-nginx-phpfpm]: https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/
 [apache-modules]: https://httpd.apache.org/docs/2.4/mod/
 [prefork MPM]: https://httpd.apache.org/docs/2.4/mod/prefork.html

--- a/_posts/14-02-01-Opcode-Cache.md
+++ b/_posts/14-02-01-Opcode-Cache.md
@@ -9,7 +9,7 @@ When a PHP file is executed, it must first be compiled into [opcodes](https://ph
 
 An opcode cache prevents redundant compilation by storing opcodes in memory and reusing them on successive calls. It will typically check signature or modification time of the file first, in case there have been any changes.
 
-It's likely an opcode cache will make a significant speed improvement to your application.  Since PHP 5.5 there is one built in - [Zend OPcache][opcache-book]. Depending on your PHP package/distribution, it's usually turned on by default - check [opcache.enable](https://secure.php.net/manual/opcache.configuration.php#ini.opcache.enable) and the output of `phpinfo()` to make sure. For earlier versions there's a PECL extension.
+It's likely an opcode cache will make a significant speed improvement to your application.  Since PHP 5.5 there is one built in - [Zend OPcache][opcache-book]. Depending on your PHP package/distribution, it's usually turned on by default - check [opcache.enable](https://www.php.net/manual/opcache.configuration.php#ini.opcache.enable) and the output of `phpinfo()` to make sure. For earlier versions there's a PECL extension.
 
 Read more about opcode caches:
 
@@ -20,7 +20,7 @@ Read more about opcode caches:
 * [PHP Preloading] - PHP >= 7.4
 
 
-[opcache-book]: https://secure.php.net/book.opcache
+[opcache-book]: https://www.php.net/book.opcache
 [Zend Optimizer+]: https://github.com/zendtech/ZendOptimizerPlus
 [WinCache]: https://www.iis.net/downloads/microsoft/wincache-extension
 [PHP_accelerators]: https://wikipedia.org/wiki/List_of_PHP_accelerators

--- a/_posts/14-03-01-Object-Caching.md
+++ b/_posts/14-03-01-Object-Caching.md
@@ -51,4 +51,4 @@ object cache to PHP 5.5+, since PHP now has a built-in bytecode cache (OPcache).
 * [APCu Documentation](https://www.php.net/apcu)
 * [Memcached](https://memcached.org/)
 * [Redis](https://redis.io/)
-* [WinCache Functions](https://secure.php.net/ref.wincache)
+* [WinCache Functions](https://www.php.net/ref.wincache)

--- a/_posts/16-02-01-From-the-Source.md
+++ b/_posts/16-02-01-From-the-Source.md
@@ -6,5 +6,5 @@ anchor:  from_the_source
 
 ## From the Source {#from_the_source_title}
 
-* [PHP Website](https://secure.php.net/)
-* [PHP Documentation](https://secure.php.net/docs.php)
+* [PHP Website](https://www.php.net/)
+* [PHP Documentation](https://www.php.net/docs.php)

--- a/_posts/17-01-01-Community.md
+++ b/_posts/17-01-01-Community.md
@@ -16,4 +16,4 @@ friends! Other community resources include [StackOverflow][php-so].
 [php-irc]: https://webchat.freenode.net/?channels=phpc
 [phpc-twitter]: https://twitter.com/phpc
 [php-so]: https://stackoverflow.com/questions/tagged/php
-[php-calendar]: https://secure.php.net/cal.php
+[php-calendar]: https://www.php.net/cal.php

--- a/_posts/17-03-01-Conferences.md
+++ b/_posts/17-03-01-Conferences.md
@@ -12,4 +12,4 @@ industry leaders.
 [Find a PHP Conference][php-conf]
 
 
-[php-conf]: https://secure.php.net/conferences/index.php
+[php-conf]: https://www.php.net/conferences/index.php

--- a/_posts/17-04-01-Elephpants.md
+++ b/_posts/17-04-01-Elephpants.md
@@ -10,6 +10,6 @@ anchor:  elephpants
 [Interview with Vincent Pontier][vincent-pontier-interview]
 
 
-[elephpant]: https://secure.php.net/elephpant.php
+[elephpant]: https://www.php.net/elephpant.php
 [vincent-pontier-interview]: https://7php.com/elephpant/
 [vincent-pontier]: http://www.elroubio.net/


### PR DESCRIPTION
Hello, this updates php.net links to current https://www.php.net site. Previous https://secure.php.net has been established due to SSL certificate issues but it now points and redirects properly to a single URL.

One additional update was done with the CLI options links because there were duplicated links.