### PR TITLE
Remove unused Homebrew PHP link

### DIFF
--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -72,7 +72,6 @@ The solutions listed above mainly handle PHP itself, and do not supply things li
 you and tie them all together, but ease of setup comes with a trade-off of flexibility.
 
 [Homebrew]: https://brew.sh/
-[Homebrew PHP]: https://github.com/Homebrew/homebrew-php#installation
 [MacPorts]: https://www.macports.org/install.php
 [phpbrew]: https://github.com/phpbrew/phpbrew
 [php-osx.liip.ch]: https://web.archive.org/web/20220505163210/https://php-osx.liip.ch/


### PR DESCRIPTION
Homebrew PHP was once a separate GitHub repository and was removed in the past.