### PR TITLE
Reword mysql extension chapter

### DIFF
--- a/_posts/07-02-01-Databases_MySQL.md
+++ b/_posts/07-02-01-Databases_MySQL.md
@@ -11,15 +11,15 @@ The [mysql] extension for PHP is incredibly old and has been superseded by two o
 - [mysqli]
 - [pdo]
 
-Not only did development stop long ago on [mysql], but it was [deprecated as of PHP 5.5.0]
-[mysql_deprecated], and **has been [officially removed in PHP 7.0][mysql_removed]**.
+Not only did development stop long ago on [mysql], but it
+**has been [officially removed in PHP 7.0][mysql_removed]**.
 
 To save digging into your `php.ini` settings to see which module you are using, one option is to search for `mysql_*`
 in your editor of choice. If any functions such as `mysql_connect()` and `mysql_query()` show up, then `mysql` is
 in use.
 
-Even if you are not using PHP 7.x yet, failing to consider this upgrade as soon as possible will lead to greater
-hardship when the PHP 7.x upgrade does come about. The best option is to replace mysql usage with [mysqli] or [PDO] in
+Even if you are not using PHP 7.x or later yet, failing to consider this upgrade as soon as possible will lead to greater
+hardship when the PHP upgrade does come about. The best option is to replace mysql usage with [mysqli] or [PDO] in
 your applications within your own development schedules so you won't be rushed later on.
 
 **If you are upgrading from [mysql] to [mysqli], beware lazy upgrade guides that suggest you can simply find and replace `mysql_*` with `mysqli_*`. Not only is that a gross oversimplification, it misses out on the advantages that mysqli provides, such as parameter binding, which is also offered in [PDO][pdo].**
@@ -28,7 +28,6 @@ your applications within your own development schedules so you won't be rushed l
 * [PHP: Choosing an API for MySQL][mysql_api]
 
 [mysql]: https://www.php.net/mysqli
-[mysql_deprecated]: https://www.php.net/migration55.deprecated
 [mysql_removed]: https://www.php.net/manual/migration70.removed-exts-sapis.php
 [mysqli]: https://www.php.net/mysqli
 [pdo]: https://www.php.net/pdo


### PR DESCRIPTION
- The ext/mysql deprecation chapter has been removed from the PHP manual.