### PR TITLE
Update PHP_CodeSniffer location to GitHub

### DIFF
--- a/_posts/02-01-01-Code-Style-Guide.md
+++ b/_posts/02-01-01-Code-Style-Guide.md
@@ -63,7 +63,7 @@ Finally, a good supplementary resource for writing clean PHP code is [Clean Code
 [psr4]: https://www.php-fig.org/psr/psr-4/
 [pear-cs]: https://pear.php.net/manual/en/standards.php
 [symfony-cs]: https://symfony.com/doc/current/contributing/code/standards.html
-[phpcs]: https://pear.php.net/package/PHP_CodeSniffer/
+[phpcs]: https://github.com/squizlabs/PHP_CodeSniffer
 [phpcbf]: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically
 [st-cs]: https://github.com/benmatselby/sublime-phpcs
 [phpcsfixer]: https://cs.symfony.com/


### PR DESCRIPTION
Hello, I believe that it's good to know that PEAR is there, yet reader should be pointed to a GitHub repository README instead.