### PR TITLE
Use jekyll-seo-tag plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,11 @@ defaults:
           path: ""
       values:
           sitemap: false
+          image:
+            path: /images/og-image.png
+            width: 1024
+            height: 640
+            alt: "PHP: The Right Way"
 
 # Excludes should be appended to the default
 # https://github.com/jekyll/jekyll/blob/master/lib/site_template/_config.yml#L37-L55
@@ -27,7 +32,9 @@ exclude:
    - gemfiles/
    - Gemfile
    - Gemfile.lock
+   - Gruntfile.js
    - node_modules/
+   - package.json
    - vendor/bundle/
    - vendor/cache/
    - vendor/gems/
@@ -39,3 +46,8 @@ exclude:
    - pages/example.md
 
 future: true
+
+title: "PHP: The Right Way"
+tagline: Reference for PHP best practices
+description: An easy-to-read, quick reference for PHP best practices, accepted coding standards, and links to authoritative PHP tutorials around the Web
+logo: /images/og-image.png

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,17 +2,11 @@
 <html lang="en">
     <head>
         <meta charset="utf-8"/>
-        <title>{% if page.title %}{{ page.title }} - {% endif %}PHP: The Right Way</title>
-        <meta name="description" content="{{ page.description }}"/>
+
+        {% seo %}
+
         <meta name="robots" content="index,follow,archive"/>
-        <meta property="og:image:url" content="https://www.phptherightway.com/images/og-image.png"/>
-        <meta property="og:image:width" content="1024"/>
-        <meta property="og:image:height" content="640"/>
-        <meta property="og:title" content="PHP: The Right Way"/>
-        <meta property="og:description" content="An easy-to-read, quick reference for PHP best practices, accepted coding standards, and links to authoritative PHP tutorials around the Web"/>
-        <meta property="og:url" content="https://www.phptherightway.com"/>
-        <meta property="og:site_name" content="PHP: The Right Way"/>
-        <meta property="og:type" content="website"/>
+
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
         <link rel="icon" href="{{ site.baseurl }}images/favicon.png" type="image/png"/>
         <link rel="stylesheet" href="{{ site.baseurl }}styles/syntax.css">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,17 +2,11 @@
 <html lang="en">
     <head>
         <meta charset="utf-8"/>
-        <title>{% if page.title %}{{ page.title }} - {% endif %}PHP: The Right Way</title>
-        <meta name="description" content="{{ page.description }}"/>
+
+        {% seo %}
+
         <meta name="robots" content="index,follow,archive"/>
-        <meta property="og:image:url" content="https://www.phptherightway.com/images/og-image.png"/>
-        <meta property="og:image:width" content="1024"/>
-        <meta property="og:image:height" content="640"/>
-        <meta property="og:title" content="PHP: The Right Way"/>
-        <meta property="og:description" content="An easy-to-read, quick reference for PHP best practices, accepted coding standards, and links to authoritative PHP tutorials around the Web"/>
-        <meta property="og:url" content="https://www.phptherightway.com"/>
-        <meta property="og:site_name" content="PHP: The Right Way"/>
-        <meta property="og:type" content="website"/>
+
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
         <link rel="icon" href="{{ site.baseurl }}images/favicon.png" type="image/png"/>
         <link rel="stylesheet" href="{{ site.baseurl }}styles/syntax.css">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-description: "An easy-to-read, quick reference for PHP best practices, accepted coding standards, and links to authoritative PHP tutorials around the Web"
 sitemap: true
 ---
 


### PR DESCRIPTION
There is a jekyll-seo-tag plugin used on GitHub pages that can automatically output SEO metadata and add Open Graph with Twitter cards tags etc.

I've added additionally this value `tagline: Reference for PHP best practices` which is appended to title on the index page.

https://pages.github.com/versions/