### PR TITLE
Update advice for unserializing user input

### DIFF
--- a/_posts/10-04-01-Data-Filtering.md
+++ b/_posts/10-04-01-Data-Filtering.md
@@ -52,7 +52,7 @@ libraries like [HTML Purifier][html-purifier] exist for this reason.
 
 It is dangerous to `unserialize()` data from users or other untrusted sources.  Doing so can allow malicious users to instantiate objects (with user-defined properties) whose destructors will be executed, **even if the objects themselves aren't used**.  You should therefore avoid unserializing untrusted data.
 
-If you absolutely must unserialize data from untrusted sources, use PHP 7's [`allowed_classes`][unserialize] option to restrict which object types are allowed to be unserialized.
+Use a safe, standard data interchange format such as JSON (via [`json_decode`][json_decode] and [`json_encode`][json_encode]) if you need to pass serialized data to the user.
 
 ### Validation
 
@@ -69,4 +69,5 @@ phone number, or age when processing a registration submission.
 [5]: https://www.php.net/function.filter-input
 [6]: https://www.php.net/security.filesystem.nullbytes
 [html-purifier]: http://htmlpurifier.org/
-[unserialize]: https://www.php.net/manual/function.unserialize.php
+[json_decode]: https://www.php.net/manual/function.json-decode.php
+[json_encode]: https://www.php.net/manual/en/function.json-encode.php

--- a/_posts/10-04-01-Data-Filtering.md
+++ b/_posts/10-04-01-Data-Filtering.md
@@ -70,4 +70,4 @@ phone number, or age when processing a registration submission.
 [6]: https://www.php.net/security.filesystem.nullbytes
 [html-purifier]: http://htmlpurifier.org/
 [json_decode]: https://www.php.net/manual/function.json-decode.php
-[json_encode]: https://www.php.net/manual/en/function.json-encode.php
+[json_encode]: https://www.php.net/manual/function.json-encode.php


### PR DESCRIPTION
In chapter 11 (data filtering) it is advised that "If you absolutely must unserialize data from untrusted sources", you can "use PHP 7’s allowed_classes ...".

This is against PHP's own advice as the code might still be executed. See also the warning on [unserialize](https://www.php.net/manual/en/function.unserialize.php) 