### PR TITLE
Use macOS word instead of Mac

### DIFF
--- a/_posts/01-04-01-Mac-Setup.md
+++ b/_posts/01-04-01-Mac-Setup.md
@@ -3,7 +3,7 @@ isChild: true
 anchor:  mac_setup
 ---
 
-## Mac Setup {#mac_setup_title}
+## macOS Setup {#mac_setup_title}
 
 macOS comes prepackaged with PHP but it is normally a little behind the latest stable release. There are multiple ways to install the latest PHP version on macOS.
 
@@ -33,7 +33,7 @@ brew link --overwrite php@8.2
 
 The [MacPorts] Project is an open-source community initiative to design an
 easy-to-use system for compiling, installing, and upgrading either
-command-line, X11 or Aqua based open-source software on the OS X operating
+command-line, X11 or Aqua based open-source software on the macOS operating
 system.
 
 MacPorts supports pre-compiled binaries, so you don't need to recompile every
@@ -63,7 +63,7 @@ It doesn't overwrite the PHP binaries installed by Apple, but installs everythin
 
 Another option that gives you control over the version of PHP you install, is to [compile it yourself][mac-compile].
 In that case be sure to have installed either [Xcode][xcode-gcc-substitution] or Apple's substitute
-["Command Line Tools for XCode"] downloadable from Apple's Mac Developer Center.
+["Command Line Tools for XCode"] downloadable from Apple's Developer Center.
 
 ### All-in-One Installers
 

--- a/_posts/03-06-01-XDebug.md
+++ b/_posts/03-06-01-XDebug.md
@@ -35,7 +35,7 @@ values in memory.
 
 Graphical debuggers make it very easy to step through code, inspect variables, and eval code against the live runtime.
 Many IDEs have built-in or plugin-based support for graphical debugging with Xdebug. MacGDBp is a free, open-source,
-stand-alone Xdebug GUI for Mac.
+stand-alone Xdebug GUI for macOS.
 
  * [Learn more about Xdebug][xdebug-docs]
  * [Learn more about MacGDBp][macgdbp-install]

--- a/_posts/05-06-01-Internationalization-and-Localization.md
+++ b/_posts/05-06-01-Internationalization-and-Localization.md
@@ -71,7 +71,7 @@ After installed, enable it by adding `extension=gettext.so` (Linux/Unix) or `ext
 your `php.ini`.
 
 Here we will also be using [Poedit] to create translation files. You will probably find it in your system's package
-manager; it is available for Unix, Mac, and Windows, and can be [downloaded for free on their website][poedit_download]
+manager; it is available for Unix, macOS, and Windows, and can be [downloaded for free on their website][poedit_download]
 as well.
 
 ### Structure


### PR DESCRIPTION
Word macOS I believe is a bit more updated for today instead of Mac which is a name for hardware but not for the OS anymore.