### PR TITLE
Update Readme.md and welcome.md to remove the links to the German translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ You should read the `CONTRIBUTING.md` file for precise instructions and tips. Bu
 <https://www.phptherightway.com>
 
 * [English](https://www.phptherightway.com)
-* [Deutsch](https://rwetzlmayr.github.io/php-the-right-way)
 * [Español](https://phpdevenezuela.github.io/php-the-right-way)
 * [Français](https://eilgin.github.io/php-the-right-way/)
 * [Indonesia](https://id.phptherightway.com)

--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -20,7 +20,6 @@ and examples as they become available.
 _PHP: The Right Way_ is translated into many different languages:
 
 * [English](https://www.phptherightway.com)
-* [Deutsch](https://rwetzlmayr.github.io/php-the-right-way)
 * [Español](https://phpdevenezuela.github.io/php-the-right-way)
 * [Français](https://eilgin.github.io/php-the-right-way/)
 * [Indonesia](https://id.phptherightway.com)


### PR DESCRIPTION
Removed the link to the German translation as it is no longer available. The original author posted this on https://rwetzlmayr.github.io/php-the-right-way/ (translated to English)

> If you have landed here looking for the German translation of the website "PHP: The Right Way," I regret to inform you that this publication is no longer available. As a former contributor to this translation, I have decided to discontinue it and cannot provide you with information on where to find the current German version. 