### PR TITLE
Precision on when APCu cache is shared or not

### DIFF
--- a/_posts/14-03-01-Object-Caching.md
+++ b/_posts/14-03-01-Object-Caching.md
@@ -20,9 +20,11 @@ one real limitation of APCu is that it is tied to the server it's installed on. 
 installed as a separate service and can be accessed across the network, meaning that you can store objects in a
 hyper-fast data store in a central location and many different systems can pull from it.
 
-Note that when running PHP as a (Fast-)CGI application inside your webserver, every PHP process will have its own cache,
-i.e. APCu data is not shared between your worker processes. In these cases, you might want to consider using memcached
-instead, as it's not tied to the PHP processes.
+Note that whether the cache is shared across PHP processes depends on how PHP is used. When running PHP via PHP-FPM,
+the cache is shared across all processes of all pools. When running PHP as a (Fast-)CGI application inside your
+webserver, the cache is not shared, i.e every PHP process will have its own APCu data. When running PHP as a command
+line, the cache is not shared and will only exists for the duration of the command. So you have to be mindful of your
+situation and goals. And you might want to consider using memcached instead, as it's not tied to the PHP processes.
 
 In a networked configuration APCu will usually outperform memcached in terms of access speed, but memcached will be
 able to scale up faster and further. If you do not expect to have multiple servers running your application, or do not

--- a/_posts/14-03-01-Object-Caching.md
+++ b/_posts/14-03-01-Object-Caching.md
@@ -23,7 +23,7 @@ hyper-fast data store in a central location and many different systems can pull 
 Note that whether the cache is shared across PHP processes depends on how PHP is used. When running PHP via PHP-FPM,
 the cache is shared across all processes of all pools. When running PHP as a (Fast-)CGI application inside your
 webserver, the cache is not shared, i.e every PHP process will have its own APCu data. When running PHP as a command
-line, the cache is not shared and will only exists for the duration of the command. So you have to be mindful of your
+line, the cache is not shared and will only exist for the duration of the command. So you have to be mindful of your
 situation and goals. And you might want to consider using memcached instead, as it's not tied to the PHP processes.
 
 In a networked configuration APCu will usually outperform memcached in terms of access speed, but memcached will be


### PR DESCRIPTION
The information is based on https://github.com/krakjoe/apcu/issues/121#issuecomment-136091336.

The fact that PHP-FPM shares cache across all pools was verified in a real-world scenario.

Fixes #1009