### PR TITLE
Add updated Spanish translation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You should read the `CONTRIBUTING.md` file for precise instructions and tips. Bu
 <https://www.phptherightway.com>
 
 * [English](https://www.phptherightway.com)
-* [Español](https://phpdevenezuela.github.io/php-the-right-way)
+* [Español](https://es.phptherightway.com)
 * [Français](https://eilgin.github.io/php-the-right-way/)
 * [Indonesia](https://id.phptherightway.com)
 * [Italiano](https://it.phptherightway.com)

--- a/_includes/welcome.md
+++ b/_includes/welcome.md
@@ -20,7 +20,7 @@ and examples as they become available.
 _PHP: The Right Way_ is translated into many different languages:
 
 * [English](https://www.phptherightway.com)
-* [Español](https://phpdevenezuela.github.io/php-the-right-way)
+* [Español](https://es.phptherightway.com)
 * [Français](https://eilgin.github.io/php-the-right-way/)
 * [Indonesia](https://id.phptherightway.com)
 * [Italiano](https://it.phptherightway.com)


### PR DESCRIPTION
Hello, I am setting up and have been working for some time in a new & updated Spanish translation of this book. 

It has been forked from the original translation which is outdated, and then updated to the latest/current version of the book.

Currently we're sitting at more than 50% of the chapters translated.

It would be great if we could set this up with a subdomain for better visibility like: `es.phptherightway.com`.

I have already setup the [CNAME](https://github.com/wilsenhc/php-the-right-way/blob/gh-pages/CNAME) in the my own repo, and would only have to update the baseUrl variables to work with the subdomain, etc.

Currently you can look at the progress of the translation here: https://wilsenhc.github.io/php-the-right-way/

You can take a look at the repo and the progress of the translation in the list of open issues: https://github.com/wilsenhc/php-the-right-way/issues

I would like to thanks @vicmans, @DesolatorMagno, @paulohbsousa, @abr4xas for all the help they provided with this translation 🚀