### PR TITLE
Fix PHPDoc links (fixes #1015)

### DIFF
--- a/_posts/15-02-01-PHPDoc.md
+++ b/_posts/15-02-01-PHPDoc.md
@@ -15,7 +15,7 @@ Below is an example of how you might document a class with a few methods;
 <?php
 /**
  * @author A Name <a.name@example.com>
- * @link https://www.phpdoc.org/docs/latest/index.html
+ * @link https://docs.phpdoc.org/
  */
 class DateTimeHelper
 {
@@ -70,10 +70,10 @@ difference between the second and third methods' doc block is the inclusion/excl
 `@return void` explicitly informs us that there is no return; historically omitting the `@return void` statement also results in the same (no return) action.
 
 
-[tags]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/index.html
-[PHPDoc manual]: https://docs.phpdoc.org/latest/index.html
-[@author]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/author.html
-[@link]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/link.html
-[@param]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/param.html
-[@return]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/return.html
-[@throws]: https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/throws.html
+[tags]: https://docs.phpdoc.org/guide/references/phpdoc/tags/
+[PHPDoc manual]: https://docs.phpdoc.org/
+[@author]: https://docs.phpdoc.org/guide/references/phpdoc/tags/author.html
+[@link]: https://docs.phpdoc.org/guide/references/phpdoc/tags/link.html
+[@param]: https://docs.phpdoc.org/guide/references/phpdoc/tags/param.html
+[@return]: https://docs.phpdoc.org/guide/references/phpdoc/tags/return.html
+[@throws]: https://docs.phpdoc.org/guide/references/phpdoc/tags/throws.html


### PR DESCRIPTION
Paths to the current documentation of PHPDoc apparently changed some time ago, this PR updates all such links.