### PR TITLE
Update chat links to point to Libera and Discord

### DIFF
--- a/_posts/17-01-01-Community.md
+++ b/_posts/17-01-01-Community.md
@@ -6,14 +6,15 @@ anchor: community
 
 The PHP community is as diverse as it is large, and its members are ready and willing to support new PHP programmers.
 Consider joining your local PHP user group (PUG) or attending larger PHP conferences to learn more about the best
-practices shown here. You can hang out on IRC in the #phpc channel on [irc.freenode.com][php-irc] and follow the
-@phpc on [X][phpc-x] or [Mastodon][phpc-mastodon]. Get out there, meet new developers, learn new topics, and above all, make new
+practices shown here. You can hang out on IRC in the #phpc channel on [irc.libera.chat][php-irc] and follow the
+@phpc, on [Discord][php-discord], on [X][phpc-x] or [Mastodon][phpc-mastodon]. Get out there, meet new developers, learn new topics, and above all, make new
 friends! Other community resources include [StackOverflow][php-so].
 
 [Read the Official PHP Events Calendar][php-calendar]
 
 
-[php-irc]: https://webchat.freenode.net/?channels=phpc
+[php-irc]: https://web.libera.chat/#phpc
+[php-discord]: https://phpc.chat/
 [phpc-x]: https://x.com/phpc
 [phpc-mastodon]: https://phpc.social/
 [php-so]: https://stackoverflow.com/questions/tagged/php


### PR DESCRIPTION
Freenode is dead. Long live Libera!

Also, some people like Discord (related: #phpc on Libera is bridged to the same channel on the PHPC Discord)