### PR TITLE
Add Bref Cloud to PaaS Providers

### DIFF
--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -8,6 +8,7 @@ anchor:  php_paas_providers
 
 * [Amezmo](https://www.amezmo.com)
 * [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
+* [Bref Cloud](https://bref.sh/cloud)
 * [Cloudways](https://www.cloudways.com/)
 * [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform)
 * [Divio](https://www.divio.com/)


### PR DESCRIPTION
Bref Cloud is a simple PaaS to deploy Serverless PHP application into AWS with simplicity.