### PR TITLE
Fix #1036 - Add Clever Cloud to PHP PaaS Providers list

### DIFF
--- a/_posts/16-05-01-PHP-PaaS-Providers.md
+++ b/_posts/16-05-01-PHP-PaaS-Providers.md
@@ -9,6 +9,7 @@ anchor:  php_paas_providers
 * [Amezmo](https://www.amezmo.com)
 * [AWS Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/)
 * [Bref Cloud](https://bref.sh/cloud)
+* [Clever Cloud](https://clever-cloud.com)
 * [Cloudways](https://www.cloudways.com/)
 * [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform)
 * [Divio](https://www.divio.com/)


### PR DESCRIPTION
[Clever Cloud](https://clever-cloud.com) is an European cloud provider specialised on PaaS. They deploy and run PHP apps on FPM and FrankenPHP runtimes.