### PR TITLE
Add Singleton pattern code example

### DIFF
--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -71,27 +71,33 @@ one instance of a particular class. The singleton pattern enables us to do this.
 {% highlight php %}
 <?php
 
-class NotificationLogger {
-    private static $instance;
+final class NotificationLogger {
+    private static ?self $instance = null;
 
-    //The constructor is protected to prevent creating tons of instances
-    protected function __construct()
+    // The constructor is private to prevent creating instances from outside
+    private function __construct()
     {}
 
-    //Prevent cloning the instance
-    private function __clone(){}
+    // Prevent cloning the instance
+    private function __clone(): void {}
 
-    //Prevent unserialisation which would lead to create a new instance
-    public function __wakeup(){}
-
-    //Creates new instance if it does not exist, otherwise it returns the existing instance
-    public static function getInstance(){
-        self::$instance =  self::$instance ? self::$instance : new static();
-        return self::$instance;
+    // Prevent unserialisation which would lead to create a new instance (legacy PHP mechanism, kept for backward compatibility)
+    public function __wakeup(): void {
+        throw new \LogicException("Cannot unserialize singleton");
     }
 
-    public function log(string $message){
-        echo "[SINGLETON LOG] $message";
+    // Prevent unserialisation (modern PHP mechanism)
+    public function __unserialize(array $data): void {
+        throw new \LogicException("Cannot unserialize singleton");
+    }
+
+    // Creates new instance if it does not exist, otherwise it returns the existing instance
+    public static function getInstance(): self {
+        return self::$instance ??= new self();
+    }
+
+    public function log(string $message): void {
+        echo "[SINGLETON LOG] {$message}";
     }
 }
 
@@ -99,7 +105,7 @@ class NotificationLogger {
 $logger1 = NotificationLogger::getInstance();
 $logger2 = NotificationLogger::getInstance();
 
-// prove they are the same instance
+// Prove they are the same instance
 var_dump($logger1 === $logger2); // bool(true)
 $logger1->log("Application started");
 

--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -84,7 +84,7 @@ class NotificationLogger {
     //Prevent unserialisation which would lead to create a new instance
     private function __wakeup(){}
 
-    //Creates new instance if it does not exit, otherwise it returns the existing instance
+    //Creates new instance if it does not exist, otherwise it returns the existing instance
     public static function getInstance(){
         self::$instance =  self::$instance ? self::$instance : new static();
         return self::$instance;

--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -68,7 +68,42 @@ yourself a lot of trouble down the road by using factories.
 When designing web applications, it often makes sense conceptually and architecturally to allow access to one and only
 one instance of a particular class. The singleton pattern enables us to do this.
 
-**TODO: NEED NEW SINGLETON CODE EXAMPLE**
+{% highlight php %}
+<?php
+
+class NotificationLogger {
+    private static $instance;
+
+    //The constructor is protected to prevent creating tons of instances
+    protected function __construct()
+    {}
+
+    //Prevent cloning the instance
+    private function __clone(){}
+
+    //Prevent unserialisation which would lead to create a new instance
+    private function __wakeup(){}
+
+    //Creates new instance if it does not exit, otherwise it returns the existing instance
+    public static function getInstance(){
+        self::$instance =  self::$instance ? self::$instance : new static();
+        return self::$instance;
+    }
+
+    public function log(string $message){
+        echo "[SINGLETON LOG] $message";
+    }
+}
+
+// Usage
+$logger1 = NotificationLogger::getInstance();
+$logger2 = NotificationLogger::getInstance();
+
+// prove they are the same instance
+var_dump($logger1 === $logger2); // bool(true)
+$logger1->log("Application started");
+
+{% endhighlight %}
 
 The code above implements the singleton pattern using a [*static* variable](https://www.php.net/language.variables.scope#language.variables.scope.static) and the static creation method `getInstance()`.
 Note the following:

--- a/pages/Design-Patterns.md
+++ b/pages/Design-Patterns.md
@@ -82,7 +82,7 @@ class NotificationLogger {
     private function __clone(){}
 
     //Prevent unserialisation which would lead to create a new instance
-    private function __wakeup(){}
+    public function __wakeup(){}
 
     //Creates new instance if it does not exist, otherwise it returns the existing instance
     public static function getInstance(){


### PR DESCRIPTION
This PR adds a PHP code example for the Singleton design pattern, which was previously marked as TODO: NEED NEW SINGLETON CODE EXAMPLE.
The example includes:

A protected constructor to prevent direct instantiation while allowing subclassing
A private __clone() method to prevent cloning of the instance
A private __wakeup() method to prevent unserializing of the instance
A getInstance() method using late static binding with new static() to support subclassing
Inline comments explaining the purpose of each method
A usage example demonstrating that two calls to getInstance() return the exact same instance