### PR TITLE
Windows Setup: Update section

### DIFF
--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -5,30 +5,25 @@ anchor:  windows_setup
 
 ## Windows Setup {#windows_setup_title}
 
-You can download the binaries from [windows.php.net/download][php-downloads]. After the extraction of PHP, it is recommended to set the [PATH][windows-path] to the root of your PHP folder (where php.exe is located) so you can execute PHP from anywhere.
+You can download the binaries from [windows.php.net/download][php-downloads]. After the extraction of PHP, it is 
+recommended to set the [PATH][windows-path] to the root of your PHP folder (where php.exe is located) so you can execute
+PHP from anywhere.
 
-For learning and local development, you can use the built in webserver with PHP 5.4+ so you don't need to worry about
-configuring it. If you would like an "all-in-one" which includes a full-blown webserver and MySQL too then tools such
-as the [XAMPP][xampp], [EasyPHP][easyphp], [OpenServer][openserver] and [WAMP][wamp] will
-help get a Windows development environment up and running fast. That said, these tools will be a little different from
-production so be careful of environment differences if you are working on Windows and deploying to Linux.
+For learning and local development, you can use the [built-in webserver](/#builtin_web_server_title) with PHP 5.4+ so
+you don't need to worry about configuring it. If you would like an "all-in-one" which includes a full-blown webserver
+and MySQL too then tools such as the [EasyPHP][easyphp] or [OpenServer][openserver] will help get a Windows development
+environment up and running fast. That said, these tools will be a little different from production so be careful of
+environment differences if you are working on Windows and deploying to Linux.
 
-If you need to run your production system on Windows, then IIS7 will give you the most stable and best performance. You
-can use [phpmanager][phpmanager] (a GUI plugin for IIS7) to make configuring and managing PHP simple. IIS7 comes with
-FastCGI built in and ready to go, you just need to configure PHP as a handler. For support and additional resources
-there is a [dedicated area on iis.net][php-iis] for PHP.
-
-Generally running your application on different environment in development and production can lead to strange bugs popping up when you go
-live. If you are developing on Windows and deploying to Linux (or anything non-Windows) then you should consider using a [Virtual Machine](/#virtualization_title).
+Generally running your application on different environment in development and production can lead to strange bugs 
+popping up when you go live. If you are developing on Windows and deploying to Linux (or anything non-Windows) then you
+should consider using a [Virtual Machine](/#virtualization_title) or [Windows Subsystem for Linux (WSL)][wsl].
 
 Chris Tankersley has a very helpful blog post on what tools he uses to do [PHP development using Windows][windows-tools].
 
 [easyphp]: https://www.easyphp.org/
-[phpmanager]: http://phpmanager.codeplex.com/
-[openserver]: https://ospanel.io/
-[wamp]: https://www.wampserver.com/en/
-[php-downloads]: https://windows.php.net/download/
-[php-iis]: https://php.iis.net/
+[openserver]: https://ospanel.io/en/
+[php-downloads]: https://www.php.net/downloads.php?os=windows
 [windows-path]: https://www.windows-commandline.com/set-path-command-line/
 [windows-tools]: https://ctankersley.com/2016/11/13/developing-on-windows-2016/
-[xampp]: https://www.apachefriends.org/
+[wsl]: https://learn.microsoft.com/en-us/windows/wsl/

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -5,7 +5,7 @@ anchor:  windows_setup
 
 ## Windows Setup {#windows_setup_title}
 
-You can download the binaries from [windows.php.net/download][php-downloads]. After the extraction of PHP, it is 
+You can download the binaries from [the php.net download page][php-downloads]. After the extraction of PHP, it is 
 recommended to set the [PATH][windows-path] to the root of your PHP folder (where php.exe is located) so you can execute
 PHP from anywhere.
 

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -11,9 +11,9 @@ PHP from anywhere.
 
 For learning and local development, you can use the [built-in webserver](/#builtin_web_server_title) with PHP 5.4+ so
 you don't need to worry about configuring it. If you would like an "all-in-one" which includes a full-blown webserver
-and MySQL too then tools such as the [EasyPHP][easyphp] or [OpenServer][openserver] will help get a Windows development
-environment up and running fast. That said, these tools will be a little different from production so be careful of
-environment differences if you are working on Windows and deploying to Linux.
+and MySQL too then tools such as the [EasyPHP][easyphp], [OpenServer][openserver] or [WampServer][wamp] will help get a 
+Windows development environment up and running fast. That said, these tools will be a little different from 
+production so be careful of environment differences if you are working on Windows and deploying to Linux.
 
 Generally running your application on different environment in development and production can lead to strange bugs 
 popping up when you go live. If you are developing on Windows and deploying to Linux (or anything non-Windows) then you
@@ -24,6 +24,7 @@ Chris Tankersley has a very helpful blog post on what tools he uses to do [PHP d
 [easyphp]: https://www.easyphp.org/
 [openserver]: https://ospanel.io/en/
 [php-downloads]: https://www.php.net/downloads.php?os=windows
+[wamp]: https://wampserver.aviatechno.net/?lang=en
 [windows-path]: https://www.windows-commandline.com/set-path-command-line/
 [windows-tools]: https://ctankersley.com/2016/11/13/developing-on-windows-2016/
 [wsl]: https://learn.microsoft.com/en-us/windows/wsl/

--- a/_posts/01-05-01-Windows-Setup.md
+++ b/_posts/01-05-01-Windows-Setup.md
@@ -11,7 +11,7 @@ PHP from anywhere.
 
 For learning and local development, you can use the [built-in webserver](/#builtin_web_server_title) with PHP 5.4+ so
 you don't need to worry about configuring it. If you would like an "all-in-one" which includes a full-blown webserver
-and MySQL too then tools such as the [EasyPHP][easyphp], [OpenServer][openserver] or [WampServer][wamp] will help get a 
+and MySQL too, then tools such as the [EasyPHP][easyphp], [OpenServer][openserver] or [WampServer][wamp] will help get a 
 Windows development environment up and running fast. That said, these tools will be a little different from 
 production so be careful of environment differences if you are working on Windows and deploying to Linux.
 


### PR DESCRIPTION
Resolves #911 

* Remove dead / unmaintained links
* Add WSL

I'm not an IIS user, but as far as I can tell the existing section, which mentioned IIS 7 is for Windows 7 (and equivalent era Server). All the official MS docs I could find for IIS and PHP have a banned indicating the documentation is unmaintained.

I couldn't find anything which I felt added value for readers over what's currently in the PHP manual for the current state of IIS + PHP.

XAMPP appears to be unmaintained, with no releases for several years and no significant activity on their repos. PHP Manager appears to be completely dead - the CodePlex website is offline and I couldn't find anything like an official looking github repo in a brief search.